### PR TITLE
Preferred name

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -42,6 +42,7 @@ public class User implements Cloneable, Serializable {
     private String relayGuid;
 
     private String firstName;
+    private String preferredName;
     private String lastName;
 
     private ReadableInstant loginTime;
@@ -90,7 +91,6 @@ public class User implements Cloneable, Serializable {
     private String cruManagerID;
     private String cruMinistryCode;
     private String cruPayGroup;
-    private String cruPreferredName;
     private String cruSubMinistryCode;
     private Collection<String> cruProxyAddresses = Sets.newHashSet();
     private final Set<String> cruPasswordHistory = Sets.newHashSet();
@@ -116,6 +116,7 @@ public class User implements Cloneable, Serializable {
         this.theKeyGuid = source.theKeyGuid;
         this.relayGuid = source.relayGuid;
         this.firstName = source.firstName;
+        preferredName = source.preferredName;
         this.lastName = source.lastName;
         this.emailVerified = source.emailVerified;
         this.allowPasswordChange = source.allowPasswordChange;
@@ -148,7 +149,6 @@ public class User implements Cloneable, Serializable {
         this.cruManagerID = source.cruManagerID;
         this.cruMinistryCode = source.cruMinistryCode;
         this.cruPayGroup = source.cruPayGroup;
-        this.cruPreferredName = source.cruPreferredName;
         this.cruSubMinistryCode = source.cruSubMinistryCode;
         this.cruProxyAddresses.addAll(source.cruProxyAddresses);
         this.cruPasswordHistory.addAll(source.cruPasswordHistory);
@@ -239,6 +239,20 @@ public class User implements Cloneable, Serializable {
 
     public void setFirstName(final String firstName) {
         this.firstName = firstName;
+    }
+
+    @Nullable
+    public String getRawPreferredName() {
+        return preferredName;
+    }
+
+    @Nullable
+    public String getPreferredName() {
+        return !Strings.isNullOrEmpty(preferredName) ? preferredName : firstName;
+    }
+
+    public void setPreferredName(@Nullable final String name) {
+        preferredName = Objects.equal(firstName, name) ? null : name;
     }
 
     public String getLastName() {
@@ -397,12 +411,14 @@ public class User implements Cloneable, Serializable {
         this.cruPayGroup = cruPayGroup;
     }
 
+    @Deprecated
     public String getCruPreferredName() {
-        return cruPreferredName;
+        return getPreferredName();
     }
 
+    @Deprecated
     public void setCruPreferredName(String cruPreferredName) {
-        this.cruPreferredName = cruPreferredName;
+        setPreferredName(cruPreferredName);
     }
 
     public String getCruSubMinistryCode() {
@@ -694,6 +710,7 @@ public class User implements Cloneable, Serializable {
                 .add("theKeyGuid", this.getTheKeyGuid())
                 .add("relayGuid", this.getRelayGuid())
                 .add("firstName", firstName)
+                .add("preferredName", preferredName)
                 .add("lastName", lastName)
                 .add("emailVerified", emailVerified)
                 .add("allowPasswordChange", allowPasswordChange)
@@ -719,7 +736,6 @@ public class User implements Cloneable, Serializable {
                 .add("cruManagerID", cruManagerID)
                 .add("cruMinistryCode", cruMinistryCode)
                 .add("cruPayGroup", cruPayGroup)
-                .add("cruPreferredName", cruPreferredName)
                 .add("cruSubMinistryCode", cruSubMinistryCode)
                 .add("cruProxyAddresses", cruProxyAddresses)
                 .add("cruPasswordHistory", cruPasswordHistory)
@@ -741,7 +757,7 @@ public class User implements Cloneable, Serializable {
                 domainsVisited, groups, signupKey, changeEmailKey, resetPasswordKey, proposedEmail, facebookId,
                 facebookIdStrength, grPersonId, grStagePersonId, employeeId, departmentNumber, cruDesignation,
                 cruEmployeeStatus, cruGender, cruHrStatusCode, cruJobCode, cruManagerID, cruMinistryCode,
-                cruPayGroup, cruPreferredName, cruSubMinistryCode, cruProxyAddresses, cruPasswordHistory, city,
+                cruPayGroup, preferredName, cruSubMinistryCode, cruProxyAddresses, cruPasswordHistory, city,
                 state, postal, country, telephoneNumber, securityQuestion, securityAnswer);
     }
 
@@ -756,6 +772,7 @@ public class User implements Cloneable, Serializable {
                 Objects.equal(this.getTheKeyGuid(), other.getTheKeyGuid()) &&
                 Objects.equal(this.getRelayGuid(), other.getRelayGuid()) &&
                 Objects.equal(this.firstName, other.firstName) &&
+                Objects.equal(preferredName, other.preferredName) &&
                 Objects.equal(this.lastName, other.lastName) &&
                 Objects.equal(this.emailVerified, other.emailVerified) &&
                 Objects.equal(this.allowPasswordChange, other.allowPasswordChange) &&
@@ -783,7 +800,6 @@ public class User implements Cloneable, Serializable {
                 Objects.equal(this.cruManagerID, other.cruManagerID) &&
                 Objects.equal(this.cruMinistryCode, other.cruMinistryCode) &&
                 Objects.equal(this.cruPayGroup, other.cruPayGroup) &&
-                Objects.equal(this.cruPreferredName, other.cruPreferredName) &&
                 Objects.equal(this.cruSubMinistryCode, other.cruSubMinistryCode) &&
                 this.cruProxyAddresses.size() == other.cruProxyAddresses.size() && this.cruProxyAddresses.containsAll(other.cruProxyAddresses) &&
                 this.cruPasswordHistory.size() == other.cruPasswordHistory.size() &&

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
@@ -12,7 +12,6 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_MANAGER_ID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_MINISTRY_CODE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PASSWORD_HISTORY;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PAY_GROUP;
-import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PREFERRED_NAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PROXY_ADDRESSES;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_SUB_MINISTRY_CODE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_DEPARTMENT_NUMBER;
@@ -28,6 +27,7 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LOGINTIME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_OBJECTCLASS;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PASSWORD;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_POSTAL_CODE;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PREFERRED_NAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PROPOSEDEMAIL;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_RESETPASSWORDKEY;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_SECURITY_ANSWER;
@@ -54,7 +54,8 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
 
     private static final Map<Attr, Set<String>> MASK = ImmutableMap.<Attr, Set<String>>builder()
             .put(Attr.EMAIL, ImmutableSet.of(LDAP_ATTR_USERID, LDAP_FLAG_EMAILVERIFIED, LDAP_ATTR_OBJECTCLASS))
-            .put(Attr.NAME, ImmutableSet.of(LDAP_ATTR_FIRSTNAME, LDAP_ATTR_LASTNAME))
+            .put(Attr.NAME, ImmutableSet.of(LDAP_ATTR_FIRSTNAME, LDAP_ATTR_PREFERRED_NAME, LDAP_ATTR_LASTNAME,
+                    LDAP_ATTR_OBJECTCLASS))
             .put(Attr.PASSWORD, ImmutableSet.of(LDAP_ATTR_PASSWORD, LDAP_FLAG_FORCEPASSWORDCHANGE,
                     LDAP_ATTR_CRU_PASSWORD_HISTORY, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.LOGINTIME, ImmutableSet.of(LDAP_ATTR_LOGINTIME))
@@ -76,7 +77,7 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
             .put(Attr.EMPLOYEE_NUMBER, ImmutableSet.of(LDAP_ATTR_EMPLOYEE_NUMBER, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.CRU_DESIGNATION, ImmutableSet.of(LDAP_ATTR_CRU_DESIGNATION, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.CONTACT, ImmutableSet.of(LDAP_ATTR_TELEPHONE, LDAP_ATTR_OBJECTCLASS))
-            .put(Attr.CRU_PREFERRED_NAME, ImmutableSet.of(LDAP_ATTR_CRU_PREFERRED_NAME, LDAP_ATTR_OBJECTCLASS))
+            .put(Attr.CRU_PREFERRED_NAME, ImmutableSet.of(LDAP_ATTR_PREFERRED_NAME, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.CRU_PROXY_ADDRESSES, ImmutableSet.of(LDAP_ATTR_CRU_PROXY_ADDRESSES, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.HUMAN_RESOURCE, ImmutableSet.of(
                     LDAP_ATTR_DEPARTMENT_NUMBER,

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
     public static final String LDAP_ATTR_THEKEY_GUID = "thekeyGuid";
     public static final String LDAP_ATTR_PASSWORD = "userPassword";
     public static final String LDAP_ATTR_FIRSTNAME = "givenName";
+    public static final String LDAP_ATTR_PREFERRED_NAME = "cruPreferredName";
     public static final String LDAP_ATTR_LASTNAME = "sn";
     public static final String LDAP_ATTR_LOGINTIME = "loginTime";
     public static final String LDAP_ATTR_PASSWORDCHANGEDTIME = "pwdChangedTime";
@@ -67,7 +68,6 @@ public class Constants {
     public static final String LDAP_ATTR_CRU_MANAGER_ID = "cruManagerID";
     public static final String LDAP_ATTR_CRU_MINISTRY_CODE = "cruMinistryCode";
     public static final String LDAP_ATTR_CRU_PAY_GROUP = "cruPayGroup";
-    public static final String LDAP_ATTR_CRU_PREFERRED_NAME = "cruPreferredName";
     public static final String LDAP_ATTR_CRU_SUB_MINISTRY_CODE = "cruSubMinistryCode";
     public static final String LDAP_ATTR_CRU_PROXY_ADDRESSES = "cruProxyAddresses";
     public static final String LDAP_ATTR_CRU_PASSWORD_HISTORY = "cruPasswordHistory";

--- a/api/src/test/java/org/ccci/idm/user/UserTest.java
+++ b/api/src/test/java/org/ccci/idm/user/UserTest.java
@@ -4,9 +4,11 @@ import static org.ccci.idm.user.TestUtil.guid;
 import static org.ccci.idm.user.TestUtil.randomEmail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.base.Strings;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 
@@ -80,6 +82,62 @@ public class UserTest {
             assertEquals(relayGuid, user.getRawRelayGuid());
             assertEquals(relayGuid, user.getRelayGuid());
         }
+    }
+
+    @Test
+    public void testPreferredNameNotSet() throws Exception {
+        // initialize user object
+        final User user = new User();
+        user.setFirstName("First");
+        user.setPreferredName(null);
+        assertNull(user.getRawPreferredName());
+        assertEquals(user.getFirstName(), user.getPreferredName());
+
+        // update first name
+        user.setFirstName("New Name!");
+        assertNull(user.getRawPreferredName());
+        assertEquals(user.getFirstName(), user.getPreferredName());
+        assertNotEquals("First", user.getPreferredName());
+    }
+
+    @Test
+    public void testPreferredNameSet() throws Exception {
+        // initialize user object
+        final User user = new User();
+        user.setFirstName("First");
+        user.setPreferredName("Preferred");
+        assertEquals("Preferred", user.getRawPreferredName());
+        assertEquals("Preferred", user.getPreferredName());
+        assertNotEquals(user.getFirstName(), user.getPreferredName());
+
+        // update first name
+        user.setFirstName("Second");
+        assertEquals("Preferred", user.getRawPreferredName());
+        assertEquals("Preferred", user.getPreferredName());
+        assertNotEquals(user.getFirstName(), user.getPreferredName());
+
+        // update preferred name
+        user.setPreferredName("Preferred 2");
+        assertEquals("Preferred 2", user.getRawPreferredName());
+        assertEquals("Preferred 2", user.getPreferredName());
+        assertNotEquals(user.getFirstName(), user.getPreferredName());
+    }
+
+    @Test
+    public void verifySetPreferredName() {
+        // initialize user object
+        final User user = new User();
+        user.setFirstName("First");
+        user.setPreferredName("Preferred");
+        assertEquals("Preferred", user.getRawPreferredName());
+
+        // update preferred name to first name
+        user.setPreferredName(user.getFirstName());
+        assertTrue(Strings.isNullOrEmpty(user.getRawPreferredName()));
+
+        // update preferred name to another name
+        user.setPreferredName("Other");
+        assertEquals("Other", user.getRawPreferredName());
     }
 
     @Test

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -13,7 +13,6 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_MANAGER_ID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_MINISTRY_CODE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PASSWORD_HISTORY;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PAY_GROUP;
-import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PREFERRED_NAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_PROXY_ADDRESSES;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_CRU_SUB_MINISTRY_CODE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_DEPARTMENT_NUMBER;
@@ -32,6 +31,7 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_OBJECTCLASS;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PASSWORD;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PASSWORDCHANGEDTIME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_POSTAL_CODE;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PREFERRED_NAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_PROPOSEDEMAIL;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_RELAY_GUID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_RESETPASSWORDKEY;
@@ -142,6 +142,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         entry.addAttribute(this.attr(LDAP_ATTR_RELAY_GUID, user.getRelayGuid()));
         entry.addAttribute(this.attr(LDAP_ATTR_THEKEY_GUID, user.getTheKeyGuid()));
         entry.addAttribute(this.attr(LDAP_ATTR_FIRSTNAME, user.getFirstName()));
+        entry.addAttribute(attr(LDAP_ATTR_PREFERRED_NAME, user.getPreferredName()));
         entry.addAttribute(this.attr(LDAP_ATTR_LASTNAME, user.getLastName()));
 
         // set several flags for this user
@@ -189,7 +190,6 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_MANAGER_ID, user.getCruManagerID()));
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_MINISTRY_CODE, user.getCruMinistryCode()));
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_PAY_GROUP, user.getCruPayGroup()));
-        entry.addAttribute(this.attr(LDAP_ATTR_CRU_PREFERRED_NAME, user.getCruPreferredName()));
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_SUB_MINISTRY_CODE, user.getCruSubMinistryCode()));
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_PROXY_ADDRESSES, user.getCruProxyAddresses()));
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_PASSWORD_HISTORY, user.getCruPasswordHistory()));
@@ -230,6 +230,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         user.setRelayGuid(this.getStringValue(entry, LDAP_ATTR_RELAY_GUID));
         user.setTheKeyGuid(this.getStringValue(entry, LDAP_ATTR_THEKEY_GUID));
         user.setFirstName(this.getStringValue(entry, LDAP_ATTR_FIRSTNAME));
+        user.setPreferredName(getStringValue(entry, LDAP_ATTR_PREFERRED_NAME));
         user.setLastName(this.getStringValue(entry, LDAP_ATTR_LASTNAME));
 
         // Meta-data
@@ -272,7 +273,6 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         user.setCruManagerID(this.getStringValue(entry, LDAP_ATTR_CRU_MANAGER_ID));
         user.setCruMinistryCode(this.getStringValue(entry, LDAP_ATTR_CRU_MINISTRY_CODE));
         user.setCruPayGroup(this.getStringValue(entry, LDAP_ATTR_CRU_PAY_GROUP));
-        user.setCruPreferredName(this.getStringValue(entry, LDAP_ATTR_CRU_PREFERRED_NAME));
         user.setCruSubMinistryCode(this.getStringValue(entry, LDAP_ATTR_CRU_SUB_MINISTRY_CODE));
         user.setCruProxyAddresses(this.getStringValues(entry, LDAP_ATTR_CRU_PROXY_ADDRESSES));
         user.setCruPasswordHistory(this.getStringValues(entry, LDAP_ATTR_CRU_PASSWORD_HISTORY));


### PR DESCRIPTION
- Make preferredName part of the core name attribute set
- internally only track preferredNames that are different from firstName
- in eDirectory store fully resolved preferredName