### PR TITLE
Inspektr upgrade

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.4.4-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-api</artifactId>

--- a/inspektr-legacy/pom.xml
+++ b/inspektr-legacy/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.4.4-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-inspektr-legacy</artifactId>

--- a/inspektr-legacy/pom.xml
+++ b/inspektr-legacy/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.ccci.gto</groupId>
+    <artifactId>idm-user-management</artifactId>
+    <version>0.4.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>idm-user-management-inspektr-legacy</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ccci.gto</groupId>
+      <artifactId>idm-user-management-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jasig.inspektr</groupId>
+      <artifactId>inspektr-audit</artifactId>
+      <version>${inspektr.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/resolver/ReturnUserAuditResourceResolver.java
+++ b/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/resolver/ReturnUserAuditResourceResolver.java
@@ -1,0 +1,24 @@
+package org.ccci.idm.user.inspektr.resolver;
+
+import static org.ccci.idm.user.inspektr.util.InspektrSerializationUtils.userToStringHelper;
+
+import org.aspectj.lang.JoinPoint;
+import org.ccci.idm.user.User;
+import org.jasig.inspektr.audit.spi.AuditResourceResolver;
+
+public class ReturnUserAuditResourceResolver implements AuditResourceResolver {
+    @Override
+    public String[] resolveFrom(final JoinPoint target, final Object returnValue) {
+        final User user = returnValue instanceof User ? (User) returnValue : null;
+        return new String[]{userToStringHelper(user).toString()};
+    }
+
+    @Override
+    public String[] resolveFrom(final JoinPoint auditableTarget, final Exception exception) {
+        final String message = exception.getMessage();
+        if (message != null) {
+            return new String[]{message};
+        }
+        return new String[]{exception.toString()};
+    }
+}

--- a/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UpdateUserAuditResourceResolver.java
+++ b/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UpdateUserAuditResourceResolver.java
@@ -1,0 +1,54 @@
+package org.ccci.idm.user.inspektr.spi;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import org.ccci.idm.user.User;
+import org.ccci.idm.user.User.Attr;
+
+import javax.annotation.Nonnull;
+
+public class UpdateUserAuditResourceResolver extends UserAuditResourceResolver {
+    @Override
+    protected String[] createResource(final Object[] args) {
+        if (args.length >= 2 && args[0] instanceof User && args[1] instanceof Attr[]) {
+            final User user = (User) args[0];
+            final Attr[] attrs = (Attr[]) args[1];
+
+            // generate Attr[] output
+            final ToStringHelper attrsStr = MoreObjects.toStringHelper("Attrs");
+            for (final Attr attr : (Attr[]) args[1]) {
+                attrsStr.addValue(attr);
+            }
+
+            return new String[]{userToString(user, attrs) + " " + attrsStr};
+        }
+
+        return super.createResource(args);
+    }
+
+    @Nonnull
+    protected ToStringHelper userToString(@Nonnull final User user, @Nonnull final Attr[] attrs) {
+        final ToStringHelper output = userToString(user);
+
+        for (final Attr attr : attrs) {
+            if (attr != null) {
+                switch (attr) {
+                    case NAME:
+                        output.add("firstName", user.getFirstName()).add("lastName", user.getLastName());
+                        break;
+                    case FACEBOOK:
+                        output.add("facebookId", user.getFacebookId());
+                        break;
+                    case EMAIL:
+                        // email was already added in base method, so no need to add it again
+                    case PASSWORD:
+                        // don't actually log the password...
+                    default:
+                        // do nothing for unhandled attributes
+                }
+            }
+        }
+
+        return output;
+    }
+}

--- a/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
+++ b/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
@@ -1,0 +1,26 @@
+package org.ccci.idm.user.inspektr.spi;
+
+import static org.ccci.idm.user.inspektr.util.InspektrSerializationUtils.userToStringHelper;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+import org.ccci.idm.user.User;
+import org.jasig.inspektr.audit.spi.support.AbstractAuditResourceResolver;
+
+import javax.annotation.Nonnull;
+
+public class UserAuditResourceResolver extends AbstractAuditResourceResolver {
+    @Override
+    protected String[] createResource(final Object[] args) {
+        if (args.length >= 1 && args[0] instanceof User) {
+            final User user = (User) args[0];
+            return new String[]{userToString(user).toString()};
+        }
+
+        return null;
+    }
+
+    @Nonnull
+    protected ToStringHelper userToString(@Nonnull final User user) {
+        return userToStringHelper(user);
+    }
+}

--- a/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UserGroupAuditResourceResolver.java
+++ b/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/spi/UserGroupAuditResourceResolver.java
@@ -1,0 +1,19 @@
+package org.ccci.idm.user.inspektr.spi;
+
+import static org.ccci.idm.user.inspektr.util.InspektrSerializationUtils.groupToString;
+
+import org.ccci.idm.user.Group;
+import org.ccci.idm.user.User;
+
+public class UserGroupAuditResourceResolver extends UserAuditResourceResolver {
+    @Override
+    protected String[] createResource(final Object[] args) {
+        if (args.length >= 2 && args[0] instanceof User && args[1] instanceof Group) {
+            final User user = (User) args[0];
+            final Group group = (Group) args[1];
+            return new String[]{userToString(user) + " " + groupToString(group)};
+        }
+
+        return null;
+    }
+}

--- a/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/util/InspektrSerializationUtils.java
+++ b/inspektr-legacy/src/main/java/org/ccci/idm/user/inspektr/util/InspektrSerializationUtils.java
@@ -1,0 +1,47 @@
+package org.ccci.idm.user.inspektr.util;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.FluentIterable;
+import org.ccci.idm.user.Dn;
+import org.ccci.idm.user.Group;
+import org.ccci.idm.user.User;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class InspektrSerializationUtils {
+    private static final Joiner COMPONENT_JOINER = Joiner.on(",");
+    private static final Function<Dn.Component, String> COMPONENT_SERIALIZER = new Function<Dn.Component, String>() {
+        @Nullable
+        @Override
+        public String apply(@Nullable final Dn.Component input) {
+            return input != null ? input.type + "=" + input.value : null;
+        }
+    };
+
+    @Nonnull
+    public static ToStringHelper userToStringHelper(@Nullable final User user) {
+        final ToStringHelper helper = MoreObjects.toStringHelper(User.class);
+        if (user != null) {
+            helper.add("guid", user.getGuid()).add("email", user.getEmail());
+        } else {
+            helper.addValue(null);
+        }
+        return helper;
+    }
+
+    @Nonnull
+    public static String groupToString(@Nonnull final Group group) {
+        final List<String> components = FluentIterable.from(group.getComponents())
+                .transform(COMPONENT_SERIALIZER)
+                .toList()
+                .reverse();
+        return MoreObjects.toStringHelper(group)
+                .addValue(COMPONENT_JOINER.join(components))
+                .toString();
+    }
+}

--- a/inspektr/pom.xml
+++ b/inspektr/pom.xml
@@ -10,6 +10,10 @@
 
   <artifactId>idm-user-management-inspektr</artifactId>
 
+  <properties>
+    <inspektr.version>1.7.GA</inspektr.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.ccci.gto</groupId>
@@ -17,7 +21,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jasig.inspektr</groupId>
+      <groupId>org.apereo.inspektr</groupId>
       <artifactId>inspektr-audit</artifactId>
       <version>${inspektr.version}</version>
     </dependency>

--- a/inspektr/pom.xml
+++ b/inspektr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.4.4-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-inspektr</artifactId>

--- a/inspektr/src/main/java/org/ccci/idm/user/inspektr/resolver/ReturnUserAuditResourceResolver.java
+++ b/inspektr/src/main/java/org/ccci/idm/user/inspektr/resolver/ReturnUserAuditResourceResolver.java
@@ -2,9 +2,9 @@ package org.ccci.idm.user.inspektr.resolver;
 
 import static org.ccci.idm.user.inspektr.util.InspektrSerializationUtils.userToStringHelper;
 
+import org.apereo.inspektr.audit.spi.AuditResourceResolver;
 import org.aspectj.lang.JoinPoint;
 import org.ccci.idm.user.User;
-import org.jasig.inspektr.audit.spi.AuditResourceResolver;
 
 public class ReturnUserAuditResourceResolver implements AuditResourceResolver {
     @Override

--- a/inspektr/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
+++ b/inspektr/src/main/java/org/ccci/idm/user/inspektr/spi/UserAuditResourceResolver.java
@@ -4,7 +4,7 @@ import static org.ccci.idm.user.inspektr.util.InspektrSerializationUtils.userToS
 
 import com.google.common.base.MoreObjects.ToStringHelper;
 import org.ccci.idm.user.User;
-import org.jasig.inspektr.audit.spi.support.AbstractAuditResourceResolver;
+import org.apereo.inspektr.audit.spi.support.AbstractAuditResourceResolver;
 
 import javax.annotation.Nonnull;
 

--- a/ldaptive/pom.xml
+++ b/ldaptive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ccci.gto</groupId>
     <artifactId>idm-user-management</artifactId>
-    <version>0.4.4-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>idm-user-management-ldaptive</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   <modules>
     <module>api</module>
     <module>inspektr</module>
+    <module>inspektr-legacy</module>
     <module>ldaptive</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>idm-user-management</artifactId>
-  <version>0.4.4-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
This PR updates the inspektr dependency for CAS 5.1.2. I'm also providing a forked legacy module to allow more gradual upgrades if needed.

Once everything is upgraded I will drop the legacy module