### PR TITLE
update FluentIterable usage to address signature change to `@Beta` method

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -166,7 +167,8 @@ public class DefaultUserManager implements UserManager {
         }
 
         // add password to history (if you have password and caller intends to set)
-        if(StringUtils.hasText(user.getPassword()) && FluentIterable.of(attrs).contains(User.Attr.PASSWORD)) {
+        if (StringUtils.hasText(user.getPassword()) && FluentIterable.from(Arrays.asList(attrs))
+                .contains(User.Attr.PASSWORD)) {
             user.setCruPasswordHistory(passwordHistoryManager.add(user.getPassword(), original.getCruPasswordHistory()));
         }
 
@@ -184,7 +186,7 @@ public class DefaultUserManager implements UserManager {
         this.validateUser(user);
 
         // validate user based on attributes being updated
-        final FluentIterable<User.Attr> fluentAttrs = FluentIterable.of(attrs);
+        final FluentIterable<User.Attr> fluentAttrs = FluentIterable.from(Arrays.asList(attrs));
         if (fluentAttrs.contains(User.Attr.EMAIL)) {
             validateEmail(user);
         }

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -75,6 +75,7 @@ import javax.annotation.Nullable;
 import javax.naming.InterruptedNamingException;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -481,7 +482,7 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
 
             final String originalDn = this.userMapper.mapDn(original);
             final String dn;
-            if (FluentIterable.of(attrs).contains(User.Attr.EMAIL)) {
+            if (FluentIterable.from(Arrays.asList(attrs)).contains(User.Attr.EMAIL)) {
                 // modify the DN if we are updating the user's email and it changed
                 dn = this.userMapper.mapDn(user);
                 if (!Objects.equal(originalDn, dn)) {


### PR DESCRIPTION
Google guava 23 updated the `FluentIterable.of()` signature to require either no items, or a single item followed by varargs.

Neither of these signatures support an array, so we just wrap the array in a list ourselves.

This method was marked `@Beta`, so it was use at our own risk. I would replace usages with a `Stream`, but we are still maintaining Java 6 compatibility