### PR TITLE
support tracking the master person id for a user

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -72,6 +72,10 @@ public class User implements Cloneable, Serializable {
 
     // Global Registry ID
     @Nullable
+    private String grMasterPersonId;
+    @Nullable
+    private String grStageMasterPersonId;
+    @Nullable
     private String grPersonId;
     @Nullable
     private String grStagePersonId;
@@ -136,6 +140,8 @@ public class User implements Cloneable, Serializable {
         this.facebookId = source.facebookId;
         this.facebookIdStrength = source.facebookIdStrength;
 
+        grMasterPersonId = source.grMasterPersonId;
+        grStageMasterPersonId = source.grStageMasterPersonId;
         grPersonId = source.grPersonId;
         grStagePersonId = source.grStagePersonId;
 
@@ -653,6 +659,24 @@ public class User implements Cloneable, Serializable {
     }
 
     @Nullable
+    public String getGrMasterPersonId() {
+        return grMasterPersonId;
+    }
+
+    public void setGrMasterPersonId(@Nullable final String id) {
+        grMasterPersonId = id;
+    }
+
+    @Nullable
+    public String getGrStageMasterPersonId() {
+        return grStageMasterPersonId;
+    }
+
+    public void setGrStageMasterPersonId(@Nullable final String id) {
+        grStageMasterPersonId = id;
+    }
+
+    @Nullable
     public String getGrPersonId() {
         return grPersonId;
     }
@@ -755,10 +779,10 @@ public class User implements Cloneable, Serializable {
         return Objects.hashCode(email, password, guid, getTheKeyGuid(), getRelayGuid(), firstName, lastName,
                 emailVerified, allowPasswordChange, forcePasswordChange, deactivated, loginDisabled, locked,
                 domainsVisited, groups, signupKey, changeEmailKey, resetPasswordKey, proposedEmail, facebookId,
-                facebookIdStrength, grPersonId, grStagePersonId, employeeId, departmentNumber, cruDesignation,
-                cruEmployeeStatus, cruGender, cruHrStatusCode, cruJobCode, cruManagerID, cruMinistryCode,
-                cruPayGroup, preferredName, cruSubMinistryCode, cruProxyAddresses, cruPasswordHistory, city,
-                state, postal, country, telephoneNumber, securityQuestion, securityAnswer);
+                facebookIdStrength, grMasterPersonId, grStageMasterPersonId, grPersonId, grStagePersonId, employeeId,
+                departmentNumber, cruDesignation, cruEmployeeStatus, cruGender, cruHrStatusCode, cruJobCode,
+                cruManagerID, cruMinistryCode, cruPayGroup, preferredName, cruSubMinistryCode, cruProxyAddresses,
+                cruPasswordHistory, city, state, postal, country, telephoneNumber, securityQuestion, securityAnswer);
     }
 
     @Override
@@ -788,6 +812,8 @@ public class User implements Cloneable, Serializable {
                 Objects.equal(this.proposedEmail, other.proposedEmail) &&
                 Objects.equal(this.facebookId, other.facebookId) &&
                 Objects.equal(this.facebookIdStrength, other.facebookIdStrength) &&
+                Objects.equal(grMasterPersonId, other.grMasterPersonId) &&
+                Objects.equal(grStageMasterPersonId, other.grStageMasterPersonId) &&
                 Objects.equal(grPersonId, other.grPersonId) &&
                 Objects.equal(grStagePersonId, other.grStagePersonId) &&
                 Objects.equal(this.employeeId, other.employeeId) &&

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
@@ -20,7 +20,9 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_EMPLOYEE_NUMBER;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FACEBOOKID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FACEBOOKIDSTRENGTH;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FIRSTNAME;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRPERSONID;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LASTNAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LOGINTIME;
@@ -67,6 +69,8 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
             .put(Attr.FACEBOOK, ImmutableSet.of(LDAP_ATTR_FACEBOOKID, LDAP_ATTR_FACEBOOKIDSTRENGTH,
                     LDAP_ATTR_OBJECTCLASS))
             .put(Attr.GLOBALREGISTRY, ImmutableSet.of(
+                    LDAP_ATTR_GRMASTERPERSONID,
+                    LDAP_ATTR_GRSTAGEMASTERPERSONID,
                     LDAP_ATTR_GRPERSONID,
                     LDAP_ATTR_GRSTAGEPERSONID,
                     LDAP_ATTR_OBJECTCLASS))

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
@@ -22,6 +22,8 @@ public class Constants {
     public static final String LDAP_ATTR_PASSWORDCHANGEDTIME = "pwdChangedTime";
     public static final String LDAP_ATTR_FACEBOOKID = "thekeyFacebookId";
     public static final String LDAP_ATTR_FACEBOOKIDSTRENGTH = "thekeyFacebookIdStrength";
+    public static final String LDAP_ATTR_GRMASTERPERSONID = "thekeyGrMasterPersonId";
+    public static final String LDAP_ATTR_GRSTAGEMASTERPERSONID = "thekeyGrStageMasterPersonId";
     public static final String LDAP_ATTR_GRPERSONID = "thekeyGrPersonId";
     public static final String LDAP_ATTR_GRSTAGEPERSONID = "thekeyGrStagePersonId";
     public static final String LDAP_ATTR_DOMAINSVISITED = "thekeyDomainVisited";

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -21,8 +21,10 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_EMPLOYEE_NUMBER;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FACEBOOKID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FACEBOOKIDSTRENGTH;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_FIRSTNAME;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GROUPS;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRPERSONID;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GUID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LASTNAME;
@@ -178,6 +180,8 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
                 user.getFacebookIdStrengthFor(facebookId))));
 
         // Global Registry attributes
+        entry.addAttribute(attr(LDAP_ATTR_GRMASTERPERSONID, user.getGrMasterPersonId()));
+        entry.addAttribute(attr(LDAP_ATTR_GRSTAGEMASTERPERSONID, user.getGrStageMasterPersonId()));
         entry.addAttribute(attr(LDAP_ATTR_GRPERSONID, user.getGrPersonId()));
         entry.addAttribute(attr(LDAP_ATTR_GRSTAGEPERSONID, user.getGrStagePersonId()));
 
@@ -244,6 +248,8 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         }
 
         // Global Registry attributes
+        user.setGrMasterPersonId(getStringValue(entry, LDAP_ATTR_GRMASTERPERSONID));
+        user.setGrStageMasterPersonId(getStringValue(entry, LDAP_ATTR_GRSTAGEMASTERPERSONID));
         user.setGrPersonId(getStringValue(entry, LDAP_ATTR_GRPERSONID));
         user.setGrStagePersonId(getStringValue(entry, LDAP_ATTR_GRSTAGEPERSONID));
 


### PR DESCRIPTION
This adds the Master person id to the User model (ldap attributes are already created for production).

I'll be creating a v0.4.4 maintenance release since master is currently backwards incompatible with CAS 4.1.