### PR TITLE
don't attempt to store null ReadableInstants

### DIFF
--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -352,7 +352,11 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
 
     protected final LdapAttribute attr(final String name, final ReadableInstant... values) {
         final LdapAttribute attr = new LdapAttribute(name);
-        attr.addValue(TRANSCODER_INSTANT, values);
+        for (final ReadableInstant value : values) {
+            if (value != null) {
+                attr.addValue(TRANSCODER_INSTANT, value);
+            }
+        }
         return attr;
     }
 


### PR DESCRIPTION
the `LdapAttributes` created here will `REPLACE` the same attribute already in LDAP. 

When there is a null value, creating an attribute with a name no value will end up being handled as removing the attribute from the LDAP server.