### PR TITLE
track a GR sync checksum with the user object

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -90,6 +90,10 @@ public class User implements Cloneable, Serializable {
     private String grPersonId;
     @Nullable
     private String grStagePersonId;
+    @Nullable
+    private String grSyncChecksum;
+    @Nullable
+    private String grStageSyncChecksum;
 
     // miscellaneous implementation meta-data
     @Nonnull
@@ -747,6 +751,8 @@ public class User implements Cloneable, Serializable {
         }
     }
 
+    // region Global Registry related methods
+
     @Nullable
     public String getGrMasterPersonId() {
         return grMasterPersonId;
@@ -782,6 +788,26 @@ public class User implements Cloneable, Serializable {
     public void setGrStagePersonId(@Nullable final String id) {
         grStagePersonId = id;
     }
+
+    @Nullable
+    public String getGrSyncChecksum() {
+        return grSyncChecksum;
+    }
+
+    public void setGrSyncChecksum(@Nullable final String checksum) {
+        grSyncChecksum = checksum;
+    }
+
+    @Nullable
+    public String getGrStageSyncChecksum() {
+        return grStageSyncChecksum;
+    }
+
+    public void setGrStageSyncChecksum(@Nullable final String checksum) {
+        grStageSyncChecksum = checksum;
+    }
+
+    // endregion Global Registry related methods
 
     /**
      * This method is for use by UserDao &amp; UserManager implementations only and is not meant for public use.

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
@@ -24,6 +24,8 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEPERSONID;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GR_SYNC_CHECKSUM;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LASTNAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LOGINTIME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_MFA_INTRUDER_ATTEMPTS;
@@ -77,6 +79,8 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
                     LDAP_ATTR_GRSTAGEMASTERPERSONID,
                     LDAP_ATTR_GRPERSONID,
                     LDAP_ATTR_GRSTAGEPERSONID,
+                    LDAP_ATTR_GR_SYNC_CHECKSUM,
+                    LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE,
                     LDAP_ATTR_OBJECTCLASS))
             .put(Attr.LOCATION, ImmutableSet.of(LDAP_ATTR_CITY, LDAP_ATTR_STATE, LDAP_ATTR_POSTAL_CODE,
                     LDAP_ATTR_COUNTRY, LDAP_ATTR_OBJECTCLASS))

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
@@ -22,11 +22,15 @@ public class Constants {
     public static final String LDAP_ATTR_PASSWORDCHANGEDTIME = "pwdChangedTime";
     public static final String LDAP_ATTR_FACEBOOKID = "thekeyFacebookId";
     public static final String LDAP_ATTR_FACEBOOKIDSTRENGTH = "thekeyFacebookIdStrength";
+    public static final String LDAP_ATTR_DOMAINSVISITED = "thekeyDomainVisited";
+
+    // LDAP GR attributes
     public static final String LDAP_ATTR_GRMASTERPERSONID = "thekeyGrMasterPersonId";
     public static final String LDAP_ATTR_GRSTAGEMASTERPERSONID = "thekeyGrStageMasterPersonId";
     public static final String LDAP_ATTR_GRPERSONID = "thekeyGrPersonId";
     public static final String LDAP_ATTR_GRSTAGEPERSONID = "thekeyGrStagePersonId";
-    public static final String LDAP_ATTR_DOMAINSVISITED = "thekeyDomainVisited";
+    public static final String LDAP_ATTR_GR_SYNC_CHECKSUM = "thekeyGrSyncChecksum";
+    public static final String LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE = "thekeyGrStageSyncChecksum";
 
     // LDAP MFA attributes
     public static final String LDAP_ATTR_MFA_BYPASS = "thekeyMfaBypass";

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -26,6 +26,8 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GROUPS;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEMASTERPERSONID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GRSTAGEPERSONID;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GR_SYNC_CHECKSUM;
+import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_GUID;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LASTNAME;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_ATTR_LOGINTIME;
@@ -199,6 +201,8 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         entry.addAttribute(attr(LDAP_ATTR_GRSTAGEMASTERPERSONID, user.getGrStageMasterPersonId()));
         entry.addAttribute(attr(LDAP_ATTR_GRPERSONID, user.getGrPersonId()));
         entry.addAttribute(attr(LDAP_ATTR_GRSTAGEPERSONID, user.getGrStagePersonId()));
+        entry.addAttribute(attr(LDAP_ATTR_GR_SYNC_CHECKSUM, user.getGrSyncChecksum()));
+        entry.addAttribute(attr(LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE, user.getGrStageSyncChecksum()));
 
         // cru person attributes
         entry.addAttribute(this.attr(LDAP_ATTR_CRU_DESIGNATION, user.getCruDesignation()));
@@ -274,6 +278,8 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         user.setGrStageMasterPersonId(getStringValue(entry, LDAP_ATTR_GRSTAGEMASTERPERSONID));
         user.setGrPersonId(getStringValue(entry, LDAP_ATTR_GRPERSONID));
         user.setGrStagePersonId(getStringValue(entry, LDAP_ATTR_GRSTAGEPERSONID));
+        user.setGrSyncChecksum(getStringValue(entry, LDAP_ATTR_GR_SYNC_CHECKSUM));
+        user.setGrStageSyncChecksum(getStringValue(entry, LDAP_ATTR_GR_SYNC_CHECKSUM_STAGE));
 
         // Multi-value attributes
         user.setGroups(this.getGroupValues(entry, LDAP_ATTR_GROUPS));


### PR DESCRIPTION
This will allow us to only push users to the GR if they have changed since the last sync.

This is only the data model for the checksum, the library will have no logic for creating/using the checksum.