### PR TITLE
Deprecate ccci guid

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -361,7 +361,7 @@ public class DefaultUserManager implements UserManager {
     @Override
     public User getFreshUser(@Nonnull final User user) throws UserNotFoundException {
         // attempt retrieving the fresh user object using the original users guid
-        final User fresh = userDao.findByGuid(user.getGuid(), true);
+        final User fresh = userDao.findByTheKeyGuid(user.getTheKeyGuid(), true);
 
         // throw an error if the guid wasn't found
         if (fresh == null) {

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -188,11 +188,13 @@ public class DefaultUserManager implements UserManager {
     protected void setNewUserDefaults(final User user) throws UserException {
         // generate a guid for the user if there isn't a valid one already set
         int count = 0;
-        String guid = user.getGuid();
-        while (!UserUtil.isValidGuid(guid) || doesGuidExist(guid) || doesRelayGuidExist(guid) ||
-                doesTheKeyGuidExist(guid)) {
-            guid = UUID.randomUUID().toString().toUpperCase(Locale.US);
+        while (!UserUtil.isValidGuid(user.getGuid()) || doesGuidExist(user.getGuid()) ||
+                !UserUtil.isValidGuid(user.getRelayGuid()) || doesRelayGuidExist(user.getRelayGuid()) ||
+                !UserUtil.isValidGuid(user.getTheKeyGuid()) || doesTheKeyGuidExist(user.getTheKeyGuid())) {
+            final String guid = UUID.randomUUID().toString().toUpperCase(Locale.US);
             user.setGuid(guid);
+            user.setTheKeyGuid(guid);
+            user.setRelayGuid(guid);
 
             // prevent an infinite loop, I doubt this exception will ever be thrown
             if (count++ > 200) {

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -123,6 +123,7 @@ public class DefaultUserManager implements UserManager {
         return this.userDao.isReadOnly();
     }
 
+    @Deprecated
     protected boolean doesGuidExist(final String guid) {
         return guid != null && this.userDao.findByGuid(guid, true) != null;
     }
@@ -383,11 +384,7 @@ public class DefaultUserManager implements UserManager {
     }
 
     @Override
-    public User findUserByGuid(final String guid) {
-        return this.findUserByGuid(guid, true);
-    }
-
-    @Override
+    @Deprecated
     public User findUserByGuid(final String guid, final boolean includeDeactivated) {
         return this.userDao.findByGuid(guid, includeDeactivated);
     }

--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -38,6 +38,7 @@ public class User implements Cloneable, Serializable {
     private String email;
     private String password;
 
+    @Deprecated
     private String guid;
     private String theKeyGuid;
     private String relayGuid;
@@ -230,10 +231,12 @@ public class User implements Cloneable, Serializable {
         this.forcePasswordChange = forceChange;
     }
 
+    @Deprecated
     public String getGuid() {
         return this.guid;
     }
 
+    @Deprecated
     public void setGuid(final String guid) {
         this.guid = guid;
     }

--- a/api/src/main/java/org/ccci/idm/user/UserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/UserManager.java
@@ -118,7 +118,10 @@ public interface UserManager {
      * @param guid GUID of user to find.
      * @return {@link User} with the specified guid, or <tt>null</tt> if not found.
      */
-    User findUserByGuid(String guid);
+    @Deprecated
+    default User findUserByGuid(String guid) {
+        return findUserByGuid(guid, true);
+    }
 
     /**
      * Locate the user with the specified guid.
@@ -127,6 +130,7 @@ public interface UserManager {
      * @param includeDeactivated If <tt>true</tt> then deactivated accounts are included.
      * @return {@link User} with the specified guid, or <tt>null</tt> if not found.
      */
+    @Deprecated
     User findUserByGuid(String guid, boolean includeDeactivated);
 
     /**

--- a/api/src/main/java/org/ccci/idm/user/dao/AbstractUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/AbstractUserDao.java
@@ -25,6 +25,7 @@ public abstract class AbstractUserDao implements UserDao {
     protected void assertValidUser(final User user) {
         Assert.notNull(user, "No user was provided");
         Assert.hasText(user.getEmail(), "E-mail address cannot be blank.");
-        Assert.hasText(user.getGuid(), "GUID cannot be blank");
+        Assert.hasText(user.getTheKeyGuid(), "GUID cannot be blank");
+        Assert.hasText(user.getRelayGuid(), "GUID cannot be blank");
     }
 }

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -60,6 +60,7 @@ public interface UserDao {
      * @param includeDeactivated If <tt>true</tt> then deactivated accounts are included.
      * @return Request {@link User} or <tt>null</tt> if not found.
      */
+    @Deprecated
     User findByGuid(String guid, boolean includeDeactivated);
 
     /**

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String LDAP_ATTR_OBJECTCLASS = "objectClass";
     public static final String LDAP_ATTR_CN = "cn";
     public static final String LDAP_ATTR_USERID = "uid";
+    @Deprecated
     public static final String LDAP_ATTR_GUID = "ccciGuid";
     public static final String LDAP_ATTR_THEKEY_GUID = "thekeyGuid";
     public static final String LDAP_ATTR_PASSWORD = "userPassword";

--- a/api/src/test/java/org/ccci/idm/user/DefaultUserManagerMfaTest.java
+++ b/api/src/test/java/org/ccci/idm/user/DefaultUserManagerMfaTest.java
@@ -170,7 +170,7 @@ public class DefaultUserManagerMfaTest {
 
     private User createUser() {
         final User user = newUser();
-        when(userDao.findByGuid(eq(user.getGuid()), anyBoolean())).thenReturn(user);
+        when(userDao.findByTheKeyGuid(eq(user.getTheKeyGuid()), anyBoolean())).thenReturn(user);
         return user;
     }
 }

--- a/api/src/test/java/org/ccci/idm/user/TestUtil.java
+++ b/api/src/test/java/org/ccci/idm/user/TestUtil.java
@@ -19,6 +19,7 @@ public class TestUtil {
         final User user = new User();
         user.setEmail(randomEmail());
         user.setGuid(guid());
+        user.setTheKeyGuid(guid());
         user.setRelayGuid(guid());
         user.setPassword(guid());
         user.setFirstName(randomName());

--- a/inspektr/src/main/java/org/ccci/idm/user/inspektr/util/InspektrSerializationUtils.java
+++ b/inspektr/src/main/java/org/ccci/idm/user/inspektr/util/InspektrSerializationUtils.java
@@ -27,7 +27,7 @@ public class InspektrSerializationUtils {
     public static ToStringHelper userToStringHelper(@Nullable final User user) {
         final ToStringHelper helper = MoreObjects.toStringHelper(User.class);
         if (user != null) {
-            helper.add("guid", user.getGuid()).add("email", user.getEmail());
+            helper.add("guid", user.getTheKeyGuid()).add("email", user.getEmail());
         } else {
             helper.addValue(null);
         }

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -323,6 +323,7 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
     }
 
     @Override
+    @Deprecated
     public User findByGuid(final String guid, final boolean includeDeactivated) {
         return this.findByFilter(new EqualsFilter(LDAP_ATTR_GUID, guid), includeDeactivated);
     }

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/mapper/AbstractUserLdapEntryMapper.java
@@ -131,7 +131,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
             } else if (user.getImplMeta(META_DEACTIVATED_UID, String.class) != null) {
                 uid = user.getImplMeta(META_DEACTIVATED_UID, String.class);
             } else {
-                uid = LDAP_DEACTIVATED_PREFIX + user.getGuid();
+                uid = LDAP_DEACTIVATED_PREFIX + user.getTheKeyGuid();
                 user.setImplMeta(META_DEACTIVATED_UID, uid);
             }
             return dnResolver.resolve(new org.ldaptive.auth.User(uid));
@@ -324,7 +324,7 @@ public abstract class AbstractUserLdapEntryMapper<O extends User> implements Lda
         user.setSecurityAnswer(this.getStringValue(entry, LDAP_ATTR_SECURITY_ANSWER), false);
 
         // return the loaded User object
-        LOG.debug("User loaded from LdapEntry: {}", user.getGuid());
+        LOG.debug("User loaded from LdapEntry: {}", user.getTheKeyGuid());
     }
 
     protected final LdapAttribute attr(@Nonnull final String name) {

--- a/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
+++ b/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
@@ -103,7 +103,7 @@ public class LdaptiveUserDaoIT {
         final User foundUser = this.dao.findByEmail(user.getEmail(), false);
 
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmail(), foundUser.getEmail());
     }
 
@@ -121,11 +121,11 @@ public class LdaptiveUserDaoIT {
         this.dao.update(user, User.Attr.NAME);
 
         // load user from database
-        final User foundUser = this.dao.findByGuid(user.getGuid(), false);
+        final User foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
 
         // make sure the updates persisted correctly
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmail(), foundUser.getEmail());
         assertEquals(user.getFirstName(), foundUser.getFirstName());
         assertEquals(user.getLastName(), foundUser.getLastName());
@@ -136,12 +136,12 @@ public class LdaptiveUserDaoIT {
         assumeConfigured();
 
         final User user = newUser();
-        final String guid = user.getGuid();
+        final String guid = user.getTheKeyGuid();
         user.setLoginTime(new DateTime().minusDays(30).secondOfMinute().roundFloorCopy());
         this.dao.save(user);
 
         // see if we load the same value from ldap
-        final User saved1 = this.dao.findByGuid(guid, true);
+        final User saved1 = this.dao.findByTheKeyGuid(guid, true);
         assertTrue(saved1.getLoginTime().isEqual(user.getLoginTime()));
 
         // update the login time to now
@@ -149,7 +149,7 @@ public class LdaptiveUserDaoIT {
         this.dao.update(saved1, User.Attr.LOGINTIME);
 
         // check to see if the update succeeded
-        final User saved2 = this.dao.findByGuid(guid, true);
+        final User saved2 = this.dao.findByTheKeyGuid(guid, true);
         assertTrue(saved2.getLoginTime().isEqual(saved1.getLoginTime()));
         assertFalse(saved2.getLoginTime().isEqual(user.getLoginTime()));
     }
@@ -161,11 +161,11 @@ public class LdaptiveUserDaoIT {
         // create user
         final User user = newUser();
         user.setPassword(guid());
-        final String guid = user.getGuid();
+        final String guid = user.getTheKeyGuid();
         this.dao.save(user);
 
         // check for an initial password changeTime
-        final User user1 = this.dao.findByGuid(guid, true);
+        final User user1 = this.dao.findByTheKeyGuid(guid, true);
         assertNotNull(user1);
         ReadableInstant changeTime = user1.getPasswordChangedTime();
         assertNotNull(changeTime);
@@ -178,7 +178,7 @@ public class LdaptiveUserDaoIT {
         this.dao.update(user1, User.Attr.PASSWORD);
 
         // check pwdChangedTime
-        final User user2 = this.dao.findByGuid(guid, true);
+        final User user2 = this.dao.findByTheKeyGuid(guid, true);
         assertNotNull(user2);
         assertNotNull(user2.getPasswordChangedTime());
         assertNotEquals(changeTime, user2.getPasswordChangedTime());
@@ -191,7 +191,7 @@ public class LdaptiveUserDaoIT {
         this.dao.update(user2, User.Attr.PASSWORD);
 
         // check pwdChangedTime
-        final User user3 = this.dao.findByGuid(guid, true);
+        final User user3 = this.dao.findByTheKeyGuid(guid, true);
         assertNotNull(user3);
         assertNotNull(user3.getPasswordChangedTime());
         assertNotEquals(changeTime, user3.getPasswordChangedTime());
@@ -220,55 +220,55 @@ public class LdaptiveUserDaoIT {
         // test findAllByFirstName
         {
             final Set<String> active = dao.findAllByFirstName(user1.getFirstName(), false).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
             final Set<String> all = dao.findAllByFirstName(user1.getFirstName(), true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
 
             assertEquals(1, active.size());
             assertEquals(2, all.size());
 
-            assertTrue(active.contains(user1.getGuid()));
-            assertFalse(active.contains(user2.getGuid()));
-            assertTrue(all.contains(user1.getGuid()));
-            assertTrue(all.contains(user2.getGuid()));
+            assertTrue(active.contains(user1.getTheKeyGuid()));
+            assertFalse(active.contains(user2.getTheKeyGuid()));
+            assertTrue(all.contains(user1.getTheKeyGuid()));
+            assertTrue(all.contains(user2.getTheKeyGuid()));
         }
 
         // test findAllByLastName
         {
             final Set<String> active = dao.findAllByLastName(user1.getLastName(), false).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
             final Set<String> all = dao.findAllByLastName(user1.getLastName(), true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
 
             assertEquals(1, active.size());
             assertEquals(2, all.size());
 
-            assertTrue(active.contains(user1.getGuid()));
-            assertFalse(active.contains(user2.getGuid()));
-            assertTrue(all.contains(user1.getGuid()));
-            assertTrue(all.contains(user2.getGuid()));
+            assertTrue(active.contains(user1.getTheKeyGuid()));
+            assertFalse(active.contains(user2.getTheKeyGuid()));
+            assertTrue(all.contains(user1.getTheKeyGuid()));
+            assertTrue(all.contains(user2.getTheKeyGuid()));
         }
 
         // test findAllByEmail
         {
             final Set<String> active = dao.findAllByEmail(user1.getEmail(), false).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
             final Set<String> all = this.dao.findAllByEmail(user1.getEmail(), true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
 
             assertEquals(1, active.size());
             assertEquals(2, all.size());
 
-            assertTrue(active.contains(user1.getGuid()));
-            assertFalse(active.contains(user2.getGuid()));
-            assertTrue(all.contains(user1.getGuid()));
-            assertTrue(all.contains(user2.getGuid()));
+            assertTrue(active.contains(user1.getTheKeyGuid()));
+            assertFalse(active.contains(user2.getTheKeyGuid()));
+            assertTrue(all.contains(user1.getTheKeyGuid()));
+            assertTrue(all.contains(user2.getTheKeyGuid()));
         }
 
         // create a deactivated user with unique attributes to test individual findBy* support
@@ -288,7 +288,7 @@ public class LdaptiveUserDaoIT {
             assertNull(activeUser);
             assertNotNull(anyUser);
 
-            assertEquals(user3.getGuid(), anyUser.getGuid());
+            assertEquals(user3.getTheKeyGuid(), anyUser.getTheKeyGuid());
         }
     }
 
@@ -484,9 +484,9 @@ public class LdaptiveUserDaoIT {
         this.dao.save(user);
 
         // make sure we can find it and it's valid
-        final User foundUser = this.dao.findByGuid(user.getGuid(), false);
+        final User foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmail(), foundUser.getEmail());
         assertEquals(user.getEmployeeId(), foundUser.getEmployeeId());
         assertEquals(user.getCity(), foundUser.getCity());
@@ -506,9 +506,9 @@ public class LdaptiveUserDaoIT {
         this.dao.save(user);
 
         // check that it saved correctly
-        User foundUser = this.dao.findByGuid(user.getGuid(), false);
+        User foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmail(), foundUser.getEmail());
         assertEquals(user.getCity(), foundUser.getCity());
         assertEquals(user.getEmployeeId(), foundUser.getEmployeeId());
@@ -520,9 +520,9 @@ public class LdaptiveUserDaoIT {
         this.dao.update(user, User.Attr.LOCATION, User.Attr.EMPLOYEE_NUMBER);
 
         // check for valid update
-        foundUser = this.dao.findByGuid(user.getGuid(), false);
+        foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmail(), foundUser.getEmail());
         assertEquals(user.getCity(), foundUser.getCity());
         assertEquals(user.getEmployeeId(), foundUser.getEmployeeId());
@@ -543,7 +543,7 @@ public class LdaptiveUserDaoIT {
 
         this.dao.update(user, User.Attr.SECURITYQA);
 
-        User foundUser = this.dao.findByGuid(user.getGuid(), false);
+        User foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertEquals(user.getSecurityQuestion(), foundUser.getSecurityQuestion());
         assertFalse(foundUser.checkSecurityAnswer(securityAnswer));
 
@@ -551,7 +551,7 @@ public class LdaptiveUserDaoIT {
         user.setSecurityAnswer(null);
         this.dao.update(user, User.Attr.SECURITYQA);
 
-        foundUser = this.dao.findByGuid(user.getGuid(), false);
+        foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertEquals(user.getSecurityQuestion(), foundUser.getSecurityQuestion());
         assertFalse(foundUser.checkSecurityAnswer(null));
         assertFalse(foundUser.checkSecurityAnswer("null"));
@@ -568,7 +568,7 @@ public class LdaptiveUserDaoIT {
         this.dao.update(user, User.Attr.SECURITYQA);
 
         // check for valid update
-        foundUser = this.dao.findByGuid(user.getGuid(), false);
+        foundUser = this.dao.findByTheKeyGuid(user.getTheKeyGuid(), false);
         assertEquals(user.getSecurityQuestion(), foundUser.getSecurityQuestion());
         assertTrue(foundUser.checkSecurityAnswer(securityAnswer));
 
@@ -589,7 +589,7 @@ public class LdaptiveUserDaoIT {
         // find user using designation
         final User foundUser = dao.findByDesignation(user.getCruDesignation(), false);
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getCruDesignation(), foundUser.getCruDesignation());
     }
 
@@ -604,7 +604,7 @@ public class LdaptiveUserDaoIT {
         // find staff user using employee id
         final User foundUser = this.dao.findByEmployeeId(user.getEmployeeId(), false);
         assertNotNull(foundUser);
-        assertEquals(user.getGuid(), foundUser.getGuid());
+        assertEquals(user.getTheKeyGuid(), foundUser.getTheKeyGuid());
         assertEquals(user.getEmployeeId(), foundUser.getEmployeeId());
     }
 
@@ -675,39 +675,39 @@ public class LdaptiveUserDaoIT {
         // assert the 2 users are not in the group
         {
             final Set<String> guids = dao.findAllByGroup(group1, true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
-            assertFalse(guids.contains(user1.getGuid()));
-            assertFalse(guids.contains(user2.getGuid()));
+            assertFalse(guids.contains(user1.getTheKeyGuid()));
+            assertFalse(guids.contains(user2.getTheKeyGuid()));
         }
 
         // add user1 to the group
         {
             this.dao.addToGroup(user1, group1);
             final Set<String> guids = dao.findAllByGroup(group1, true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
-            assertTrue(guids.contains(user1.getGuid()));
-            assertFalse(guids.contains(user2.getGuid()));
+            assertTrue(guids.contains(user1.getTheKeyGuid()));
+            assertFalse(guids.contains(user2.getTheKeyGuid()));
         }
 
         // add user2 to the group
         {
             this.dao.addToGroup(user2, group1);
             final Set<String> guids = dao.findAllByGroup(group1, true).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
-            assertTrue(guids.contains(user1.getGuid()));
-            assertTrue(guids.contains(user2.getGuid()));
+            assertTrue(guids.contains(user1.getTheKeyGuid()));
+            assertTrue(guids.contains(user2.getTheKeyGuid()));
         }
 
         // test includeDeactivated flag
         {
             final Set<String> guids = dao.findAllByGroup(group1, false).stream()
-                    .map(User::getGuid)
+                    .map(User::getTheKeyGuid)
                     .collect(Collectors.toSet());
-            assertTrue(guids.contains(user1.getGuid()));
-            assertFalse(guids.contains(user2.getGuid()));
+            assertTrue(guids.contains(user1.getTheKeyGuid()));
+            assertFalse(guids.contains(user2.getTheKeyGuid()));
         }
 
         // remove the users from the group


### PR DESCRIPTION
We aren't tracking the `ccciGuid` within Okta, this can potentially complicate the Okta to eDir sync. So, we are deprecating and making sure we are no longer dependent on the `ccciGuid`