### PR TITLE
OktaUserDao

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,10 +35,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>javax.validation</groupId>

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -466,6 +466,12 @@ public class DefaultUserManager implements UserManager {
     }
 
     @Override
+    public Stream<User> streamUsersInGroup(@Nonnull final Group group, @Nullable final Expression expression,
+                                           final boolean includeDeactivated) {
+        return userDao.streamUsersInGroup(group, expression, includeDeactivated, true);
+    }
+
+    @Override
     @Audit(action = AUDIT_ACTION_ADD_TO_GROUP, actionResolverName = AUDIT_ACTION_RESOLVER_USER_MANAGER,
             resourceResolverName = AUDIT_RESOURCE_RESOLVER_ADD_TO_GROUP)
     public void addToGroup(@Nonnull final User user, @Nonnull final Group group) throws DaoException {

--- a/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/DefaultUserManager.java
@@ -487,6 +487,12 @@ public class DefaultUserManager implements UserManager {
         this.userDao.removeFromGroup(user, group);
     }
 
+    @Nullable
+    @Override
+    public Group getGroup(@Nullable final String id) throws DaoException {
+        return userDao.getGroup(id);
+    }
+
     /**
      * Returns all available groups
      *

--- a/api/src/main/java/org/ccci/idm/user/User.java
+++ b/api/src/main/java/org/ccci/idm/user/User.java
@@ -111,6 +111,7 @@ public class User implements Cloneable, Serializable {
     private String cruMinistryCode;
     private String cruPayGroup;
     private String cruSubMinistryCode;
+    @Nonnull
     private Collection<String> cruProxyAddresses = Sets.newHashSet();
 
     // other attributes (used by relay)
@@ -447,12 +448,13 @@ public class User implements Cloneable, Serializable {
         this.cruSubMinistryCode = cruSubMinistryCode;
     }
 
+    @Nonnull
     public Collection<String> getCruProxyAddresses() {
         return cruProxyAddresses;
     }
 
-    public void setCruProxyAddresses(Collection<String> cruProxyAddresses) {
-        this.cruProxyAddresses = cruProxyAddresses;
+    public void setCruProxyAddresses(@Nonnull final Collection<String> addresses) {
+        cruProxyAddresses = addresses;
     }
 
     @Deprecated

--- a/api/src/main/java/org/ccci/idm/user/UserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/UserManager.java
@@ -330,6 +330,8 @@ public interface UserManager {
      */
     Stream<User> streamUsers(@Nullable Expression expression, boolean includeDeactivated, boolean restrictMaxAllowed);
 
+    Stream<User> streamUsersInGroup(@Nonnull Group group, @Nullable Expression expression, boolean includeDeactivated);
+
     /**
      * Add user to group
      *

--- a/api/src/main/java/org/ccci/idm/user/UserManager.java
+++ b/api/src/main/java/org/ccci/idm/user/UserManager.java
@@ -355,6 +355,9 @@ public interface UserManager {
      */
     void removeFromGroup(@Nonnull User user, @Nonnull Group group) throws DaoException;
 
+    @Nullable
+    Group getGroup(@Nullable String id) throws DaoException;
+
     /**
      * Returns all available groups
      *

--- a/api/src/main/java/org/ccci/idm/user/dao/AbstractUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/AbstractUserDao.java
@@ -1,10 +1,14 @@
 package org.ccci.idm.user.dao;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.ccci.idm.user.User;
 import org.ccci.idm.user.dao.exception.ReadOnlyDaoException;
 import org.springframework.util.Assert;
 
 public abstract class AbstractUserDao implements UserDao {
+    @VisibleForTesting
+    public static final int SEARCH_NO_LIMIT = 0;
+
     private boolean readOnly = false;
 
     public void setReadOnly(final boolean readOnly) {

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -189,10 +189,12 @@ public interface UserDao {
      * @return {@link List} of {@link User} objects found.
      * @throws ExceededMaximumAllowedResultsException if there are too many users found
      * @throws DaoException
+     * @deprecated Since v1.0.0, use {@link UserDao#streamUsers} instead.
      */
     @Nonnull
+    @Deprecated
     default List<User> findAllByGroup(@Nonnull Group group, boolean includeDeactivated) throws DaoException {
-        return streamUsers(Attribute.GROUP.eq(group), includeDeactivated).collect(Collectors.toList());
+        return streamUsersInGroup(group, null, includeDeactivated, true).collect(Collectors.toList());
     }
 
     /**
@@ -250,6 +252,14 @@ public interface UserDao {
      */
     @Nonnull
     Stream<User> streamUsers(@Nullable Expression expression, boolean includeDeactivated, boolean restrictMaxAllowed);
+
+    @Nonnull
+    default Stream<User> streamUsersInGroup(@Nonnull final Group group, @Nullable Expression expression,
+                                            boolean includeDeactivated, final boolean restrictMaxAllowed) {
+        final Expression groupExpression = Attribute.GROUP.eq(group);
+        return streamUsers(expression != null ? expression.and(groupExpression) : groupExpression,
+                includeDeactivated, restrictMaxAllowed);
+    }
 
     /**
      * Add user to group

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -280,6 +280,9 @@ public interface UserDao {
      */
     void removeFromGroup(@Nonnull User user, @Nonnull Group group) throws DaoException;
 
+    @Nullable
+    Group getGroup(@Nullable String id) throws DaoException;
+
     /**
      * Returns all available groups
      *

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -36,7 +36,7 @@ public interface UserDao {
      *
      * @param user User to be updated.
      */
-    void update(User user, User.Attr... attrs) throws DaoException;
+    void update(@Nonnull User user, User.Attr... attrs) throws DaoException;
 
     /**
      * Update an existing user in the persistent user store.

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -29,7 +29,7 @@ public interface UserDao {
      *
      * @param user User to be created.
      */
-    void save(User user) throws DaoException;
+    void save(@Nonnull User user) throws DaoException;
 
     /**
      * Update an existing user in the persistent user store.

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -257,7 +257,9 @@ public interface UserDao {
      * @param user to add
      * @param group to group
      */
-    void addToGroup(@Nonnull User user, @Nonnull Group group) throws DaoException;
+    default void addToGroup(@Nonnull User user, @Nonnull Group group) throws DaoException {
+        addToGroup(user, group, false);
+    }
 
     /**
      * Add user to group
@@ -266,7 +268,9 @@ public interface UserDao {
      * @param group       to add the user to
      * @param addSecurity specifies if the Group security should be shared with the user being added.
      */
-    void addToGroup(@Nonnull User user, @Nonnull Group group, boolean addSecurity) throws DaoException;
+    default void addToGroup(@Nonnull User user, @Nonnull Group group, boolean addSecurity) throws DaoException {
+        addToGroup(user, group);
+    }
 
     /**
      * Remove user from group

--- a/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/UserDao.java
@@ -111,6 +111,7 @@ public interface UserDao {
      * @param includeDeactivated If <tt>true</tt> then deactivated accounts are included.
      * @return Request {@link User} or <tt>null</tt> if not found.
      */
+    @Nullable
     User findByTheKeyGuid(String guid, boolean includeDeactivated);
 
     /**

--- a/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
+++ b/api/src/main/java/org/ccci/idm/user/dao/ldap/AbstractLdapUserDao.java
@@ -49,7 +49,6 @@ import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_FORCEPASSWORDCHANGE
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_LOCKED;
 import static org.ccci.idm.user.dao.ldap.Constants.LDAP_FLAG_LOGINDISABLED;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.ccci.idm.user.User.Attr;
@@ -59,7 +58,6 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractLdapUserDao extends AbstractUserDao {
-
     private static final Map<Attr, Set<String>> MASK = ImmutableMap.<Attr, Set<String>>builder()
             .put(Attr.EMAIL, ImmutableSet.of(LDAP_ATTR_USERID, LDAP_FLAG_EMAILVERIFIED, LDAP_ATTR_OBJECTCLASS))
             .put(Attr.NAME, ImmutableSet.of(LDAP_ATTR_FIRSTNAME, LDAP_ATTR_PREFERRED_NAME, LDAP_ATTR_LASTNAME,
@@ -113,9 +111,6 @@ public abstract class AbstractLdapUserDao extends AbstractUserDao {
 
     private Set<String> MASK_DEFAULT = ImmutableSet.<String>builder().addAll(MASK.get(Attr.EMAIL)).addAll(MASK.get
             (Attr.NAME)).addAll(MASK.get(Attr.FLAGS)).build();
-
-    @VisibleForTesting
-    public static final int SEARCH_NO_LIMIT = 0;
 
     protected int maxSearchResults = SEARCH_NO_LIMIT;
 

--- a/api/src/main/java/org/ccci/idm/user/exception/GroupException.kt
+++ b/api/src/main/java/org/ccci/idm/user/exception/GroupException.kt
@@ -1,0 +1,3 @@
+package org.ccci.idm.user.exception
+
+open class GroupException : RuntimeException()

--- a/api/src/main/java/org/ccci/idm/user/exception/GroupNotFoundException.kt
+++ b/api/src/main/java/org/ccci/idm/user/exception/GroupNotFoundException.kt
@@ -1,0 +1,3 @@
+package org.ccci.idm.user.exception
+
+class GroupNotFoundException : GroupException()

--- a/api/src/main/java/org/ccci/idm/user/exception/UserException.java
+++ b/api/src/main/java/org/ccci/idm/user/exception/UserException.java
@@ -1,6 +1,6 @@
 package org.ccci.idm.user.exception;
 
-public class UserException extends Exception {
+public class UserException extends RuntimeException {
     private static final long serialVersionUID = 2012533477643620017L;
 
     public UserException() {

--- a/api/src/main/java/org/ccci/idm/user/query/Attribute.java
+++ b/api/src/main/java/org/ccci/idm/user/query/Attribute.java
@@ -47,4 +47,12 @@ public enum Attribute {
 
         return new ComparisonExpression(ComparisonExpression.Type.LIKE, this, value);
     }
+
+    public Expression sw(@Nonnull final String value) {
+        if (this == GUID) {
+            throw new UnsupportedOperationException("You can only do direct equality searches for guids");
+        }
+
+        return new ComparisonExpression(ComparisonExpression.Type.SW, this, value);
+    }
 }

--- a/api/src/main/java/org/ccci/idm/user/query/ComparisonExpression.java
+++ b/api/src/main/java/org/ccci/idm/user/query/ComparisonExpression.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 public class ComparisonExpression implements Expression {
     private static final long serialVersionUID = 6470937370962349745L;
 
-    public enum Type {EQ, LIKE}
+    public enum Type {EQ, LIKE, SW}
 
     @Nonnull
     private final Type type;

--- a/ldaptive/pom.xml
+++ b/ldaptive/pom.xml
@@ -29,10 +29,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -384,7 +384,7 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
     }
 
     @Override
-    public void update(final User user, User.Attr... attrs) throws DaoException {
+    public void update(@Nonnull final User user, User.Attr... attrs) throws DaoException {
         assertWritable();
         assertValidUser(user);
 

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -453,6 +453,12 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
         modifyGroupMembership(AttributeModificationType.REMOVE, user, (LdapGroup) group, true);
     }
 
+    @Nullable
+    @Override
+    public Group getGroup(@Nullable final String id) throws DaoException {
+        throw new UnsupportedOperationException("getGroup() is not implemented for the LdaptiveUserDao");
+    }
+
     /**
      * Returns all available groups
      *

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -435,11 +435,6 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
     }
 
     @Override
-    public void addToGroup(@Nonnull final User user, @Nonnull final Group group) throws DaoException {
-        addToGroup(user, group, false);
-    }
-
-    @Override
     public void addToGroup(@Nonnull final User user, @Nonnull final Group group, final boolean addSecurity)
             throws DaoException {
         assertWritable();

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -298,6 +298,7 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
                 guid).and(new PresentFilter(LDAP_ATTR_RELAY_GUID).not())), includeDeactivated);
     }
 
+    @Nullable
     @Override
     public User findByTheKeyGuid(final String guid, final boolean includeDeactivated) {
         // theKeyGuid == {guid} || (guid == {guid} && theKeyGuid == null)

--- a/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
+++ b/ldaptive/src/main/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDao.java
@@ -362,7 +362,7 @@ public class LdaptiveUserDao extends AbstractLdapUserDao {
     }
 
     @Override
-    public void save(final User user) throws DaoException {
+    public void save(@Nonnull final User user) throws DaoException {
         assertWritable();
         assertValidUser(user);
 

--- a/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
+++ b/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoIT.java
@@ -2,7 +2,7 @@ package org.ccci.idm.user.ldaptive.dao;
 
 import static org.ccci.idm.user.TestUtil.guid;
 import static org.ccci.idm.user.TestUtil.newUser;
-import static org.ccci.idm.user.dao.ldap.AbstractLdapUserDao.SEARCH_NO_LIMIT;
+import static org.ccci.idm.user.dao.AbstractUserDao.SEARCH_NO_LIMIT;
 import static org.ccci.idm.user.query.Attribute.EMAIL;
 import static org.ccci.idm.user.query.Attribute.FIRST_NAME;
 import static org.ccci.idm.user.query.Attribute.LAST_NAME;

--- a/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoTest.java
+++ b/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoTest.java
@@ -1,6 +1,6 @@
 package org.ccci.idm.user.ldaptive.dao;
 
-import static org.ccci.idm.user.dao.ldap.AbstractLdapUserDao.SEARCH_NO_LIMIT;
+import static org.ccci.idm.user.dao.AbstractUserDao.SEARCH_NO_LIMIT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;

--- a/okta/pom.xml
+++ b/okta/pom.xml
@@ -21,5 +21,18 @@
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.okta.sdk</groupId>
+      <artifactId>okta-sdk-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.okta.sdk</groupId>
+      <artifactId>okta-sdk-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.okta.sdk</groupId>
+      <artifactId>okta-sdk-httpclient</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/okta/pom.xml
+++ b/okta/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.ccci.gto</groupId>
+    <artifactId>idm-user-management</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>idm-user-management-okta</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ccci.gto</groupId>
+      <artifactId>idm-user-management-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/okta/pom.xml
+++ b/okta/pom.xml
@@ -17,12 +17,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>${kotlin.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.okta.authn.sdk</groupId>
       <artifactId>okta-authn-sdk-api</artifactId>
     </dependency>

--- a/okta/pom.xml
+++ b/okta/pom.xml
@@ -23,6 +23,14 @@
     </dependency>
 
     <dependency>
+      <groupId>com.okta.authn.sdk</groupId>
+      <artifactId>okta-authn-sdk-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.okta.authn.sdk</groupId>
+      <artifactId>okta-authn-sdk-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.okta.sdk</groupId>
       <artifactId>okta-sdk-api</artifactId>
     </dependency>

--- a/okta/src/main/java/org/ccci/idm/user/okta/OktaGroup.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/OktaGroup.kt
@@ -1,0 +1,13 @@
+package org.ccci.idm.user.okta
+
+import org.ccci.idm.user.Group
+
+data class OktaGroup(
+    override val id: String? = null
+) : Group {
+    constructor(id: String? = null, name: String? = null) : this(id) {
+        this.name = name
+    }
+
+    override var name: String? = null
+}

--- a/okta/src/main/java/org/ccci/idm/user/okta/OktaGroup.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/OktaGroup.kt
@@ -10,4 +10,6 @@ data class OktaGroup(
     }
 
     override var name: String? = null
+
+    fun isDescendantOfOrEqualTo(prefix: String) = name == prefix || name?.startsWith("$prefix-") == true
 }

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/FallbackDaoOktaUserDaoListener.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/FallbackDaoOktaUserDaoListener.kt
@@ -1,0 +1,35 @@
+package org.ccci.idm.user.okta.dao
+
+import org.ccci.idm.user.User
+import org.ccci.idm.user.dao.UserDao
+
+private val UPDATABLE_ATTRS = setOf(User.Attr.MFA_SECRET, User.Attr.MFA_INTRUDER_DETECTION, User.Attr.SELFSERVICEKEYS)
+
+class FallbackDaoOktaUserDaoListener(
+    private val dao: UserDao
+) : OktaUserDao.Listener {
+    override fun onUserLoaded(user: User) {
+        dao.findByTheKeyGuid(user.theKeyGuid, true)?.run {
+            // MFA attributes
+            user.isMfaBypassed = isMfaBypassed
+            user.mfaEncryptedSecret = mfaEncryptedSecret
+            user.isMfaIntruderLocked = isMfaIntruderLocked
+            user.mfaIntruderAttempts = mfaIntruderAttempts
+            user.mfaIntruderResetTime = mfaIntruderResetTime
+
+            // self-service keys
+            user.signupKey = signupKey
+            user.proposedEmail = proposedEmail
+            user.changeEmailKey = changeEmailKey
+            user.resetPasswordKey = resetPasswordKey
+        }
+    }
+
+    override fun onUserUpdated(user: User, vararg attrs: User.Attr) {
+        val filteredAttrs = attrs.filter { UPDATABLE_ATTRS.contains(it) }
+        if (filteredAttrs.isEmpty()) return
+
+        val original = dao.findByTheKeyGuid(user.theKeyGuid, true)
+        dao.update(original, user, *filteredAttrs.toTypedArray())
+    }
+}

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/FallbackDaoOktaUserDaoListener.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/FallbackDaoOktaUserDaoListener.kt
@@ -29,7 +29,7 @@ class FallbackDaoOktaUserDaoListener(
         val filteredAttrs = attrs.filter { UPDATABLE_ATTRS.contains(it) }
         if (filteredAttrs.isEmpty()) return
 
-        val original = dao.findByTheKeyGuid(user.theKeyGuid, true)
+        val original = dao.findByTheKeyGuid(user.theKeyGuid, true) ?: return
         dao.update(original, user, *filteredAttrs.toTypedArray())
     }
 }

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -129,7 +129,8 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
         val attrsSet = EnumSet.noneOf(User.Attr::class.java).apply { addAll(attrs.ifEmpty { DEFAULT_ATTRS }) }
         if (
             attrsSet.contains(User.Attr.EMAIL) || attrsSet.contains(User.Attr.PASSWORD) ||
-            attrsSet.contains(User.Attr.NAME) || attrsSet.contains(User.Attr.CRU_PREFERRED_NAME)
+            attrsSet.contains(User.Attr.NAME) || attrsSet.contains(User.Attr.CRU_PREFERRED_NAME) ||
+            attrsSet.contains(User.Attr.EMPLOYEE_NUMBER) || attrsSet.contains(User.Attr.CRU_DESIGNATION)
         ) {
             val oktaUser = findOktaUser(user) ?: throw UserNotFoundException()
 
@@ -153,6 +154,14 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
                     }
                     User.Attr.CRU_PREFERRED_NAME -> {
                         oktaUser.profile[PROFILE_NICK_NAME] = user.rawPreferredName
+                        changed = true
+                    }
+                    User.Attr.EMPLOYEE_NUMBER -> {
+                        oktaUser.profile[PROFILE_US_EMPLOYEE_ID] = user.employeeId
+                        changed = true
+                    }
+                    User.Attr.CRU_DESIGNATION -> {
+                        oktaUser.profile[PROFILE_US_DESIGNATION] = user.cruDesignation
                         changed = true
                     }
                     // we don't care about these attributes anymore

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -29,6 +29,9 @@ private val DEFAULT_ATTRS = arrayOf(User.Attr.EMAIL, User.Attr.NAME, User.Attr.F
 class OktaUserDao(private val okta: Client, private val listeners: List<Listener>? = null) : AbstractUserDao() {
     var initialGroups: Set<String> = emptySet()
 
+    private fun findOktaUser(user: User) =
+        findOktaUserByOktaUserId(user.oktaUserId) ?: findOktaUserByTheKeyGuid(user.theKeyGuid)
+
     fun findByOktaUserId(id: String?) = findOktaUserByOktaUserId(id)?.toIdmUser()
     private fun findOktaUserByOktaUserId(id: String?) = id?.let { okta.getUser(id) }
 
@@ -80,9 +83,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             attrsSet.contains(User.Attr.EMAIL) || attrsSet.contains(User.Attr.PASSWORD) ||
             attrsSet.contains(User.Attr.NAME) || attrsSet.contains(User.Attr.CRU_PREFERRED_NAME)
         ) {
-            val oktaUser = findOktaUserByOktaUserId(user.oktaUserId)
-                ?: findOktaUserByTheKeyGuid(user.theKeyGuid)
-                ?: throw UserNotFoundException()
+            val oktaUser = findOktaUser(user) ?: throw UserNotFoundException()
 
             var changed = false
             attrsSet.forEach {

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -22,6 +22,8 @@ private const val PROFILE_US_DESIGNATION = "usDesignationNumber"
 private const val PROFILE_NICK_NAME = "nickName"
 private const val PROFILE_EMAIL_ALIASES = "emailAliases"
 
+private val DEFAULT_ATTRS = arrayOf(User.Attr.EMAIL, User.Attr.NAME, User.Attr.FLAGS)
+
 class OktaUserDao(private val okta: Client) : AbstractUserDao() {
     fun findByOktaUserId(id: String?) = findOktaUserByOktaUserId(id)?.toIdmUser()
     private fun findOktaUserByOktaUserId(id: String?) = id?.let { okta.getUser(id) }
@@ -69,7 +71,7 @@ class OktaUserDao(private val okta: Client) : AbstractUserDao() {
             ?: throw UserNotFoundException()
 
         var changed = false
-        attrs.forEach {
+        attrs.ifEmpty { DEFAULT_ATTRS }.forEach {
             when (it) {
                 User.Attr.EMAIL -> {
                     oktaUser.profile.login = user.email
@@ -90,6 +92,8 @@ class OktaUserDao(private val okta: Client) : AbstractUserDao() {
                     oktaUser.profile[PROFILE_NICK_NAME] = user.rawPreferredName
                     changed = true
                 }
+                // we don't care about these attributes anymore
+                User.Attr.DOMAINSVISITED, User.Attr.FACEBOOK, User.Attr.FLAGS -> Unit
             }
         }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -125,7 +125,12 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     }
     // endregion CRUD methods
 
-    // region Group Membership methods
+    // region Group methods
+    override fun getAllGroups(baseSearch: String?) = okta.listGroups().asSequence()
+        .map { it.asIdmGroup() }
+        .filter { baseSearch == null || it.isDescendantOfOrEqualTo(baseSearch) }
+        .toList()
+
     override fun addToGroup(user: User, group: Group) {
         require(group is OktaGroup) { "$group is not an Okta Group" }
 
@@ -139,7 +144,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
         val oktaUserId = user.oktaUserId ?: findOktaUser(user)?.id ?: throw UserNotFoundException()
         okta.getGroup(group.id)?.removeUser(oktaUserId)
     }
-    // endregion Group Membership methods
+    // endregion Group methods
 
     // region Unsupported Deprecated Methods
     override fun enqueueAll(queue: BlockingQueue<User>, deactivated: Boolean) = throw UnsupportedOperationException()
@@ -153,7 +158,6 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     override fun findByDesignation(designation: String?, includeDeactivated: Boolean) = TODO("not implemented")
     override fun findByEmployeeId(employeeId: String?, includeDeactivated: Boolean) = TODO("not implemented")
     override fun findByFacebookId(id: String?, includeDeactivated: Boolean) = TODO("not implemented")
-    override fun getAllGroups(baseSearch: String?) = TODO("not implemented")
     override fun streamUsers(expression: Expression?, deactivated: Boolean, restrict: Boolean) = TODO("not implemented")
     // endregion Unused methods
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -16,6 +16,9 @@ import com.okta.sdk.resource.user.User as OktaUser
 
 private const val PROFILE_THEKEY_GUID = "theKeyGuid"
 private const val PROFILE_RELAY_GUID = "relayGuid"
+private const val PROFILE_US_EMPLOYEE_ID = "usEmployeeId"
+private const val PROFILE_US_DESIGNATION = "usDesignationNumber"
+private const val PROFILE_EMAIL_ALIASES = "emailAliases"
 
 class OktaUserDao(private val okta: Client) : UserDao {
     override fun isReadOnly() = true
@@ -46,9 +49,12 @@ class OktaUserDao(private val okta: Client) : UserDao {
             .putProfileProperty(PROFILE_THEKEY_GUID, user.theKeyGuid)
             .putProfileProperty(PROFILE_RELAY_GUID, user.relayGuid)
             .setEmail(user.email)
+            .setPassword(user.password.toCharArray())
             .setFirstName(user.firstName)
             .setLastName(user.lastName)
-            .setPassword(user.password.toCharArray())
+            .putProfileProperty(PROFILE_US_EMPLOYEE_ID, user.employeeId)
+            .putProfileProperty(PROFILE_US_DESIGNATION, user.cruDesignation)
+            .putProfileProperty(PROFILE_EMAIL_ALIASES, user.cruProxyAddresses.toList())
             .buildAndCreate(okta)
     }
     // endregion CRUD methods
@@ -86,6 +92,9 @@ class OktaUserDao(private val okta: Client) : UserDao {
             lastName = profile.lastName
             theKeyGuid = profile.getString(PROFILE_THEKEY_GUID)
             relayGuid = profile.getString(PROFILE_RELAY_GUID)
+            employeeId = profile.getString(PROFILE_US_EMPLOYEE_ID)
+            cruDesignation = profile.getString(PROFILE_US_DESIGNATION)
+            cruProxyAddresses = profile.getStringList(PROFILE_EMAIL_ALIASES)
         }
     }
 }

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -25,9 +25,7 @@ private const val PROFILE_EMAIL_ALIASES = "emailAliases"
 
 private val DEFAULT_ATTRS = arrayOf(User.Attr.EMAIL, User.Attr.NAME, User.Attr.FLAGS)
 
-class OktaUserDao(private val okta: Client) : AbstractUserDao() {
-    val listeners: List<Listener>? = null
-
+class OktaUserDao(private val okta: Client, private val listeners: List<Listener>? = null) : AbstractUserDao() {
     fun findByOktaUserId(id: String?) = findOktaUserByOktaUserId(id)?.toIdmUser()
     private fun findOktaUserByOktaUserId(id: String?) = id?.let { okta.getUser(id) }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -2,6 +2,7 @@ package org.ccci.idm.user.okta.dao
 
 import com.okta.sdk.client.Client
 import com.okta.sdk.resource.user.EmailStatus
+import com.okta.sdk.resource.user.UserBuilder
 import org.ccci.idm.user.Group
 import org.ccci.idm.user.SearchQuery
 import org.ccci.idm.user.User
@@ -39,8 +40,20 @@ class OktaUserDao(private val okta: Client) : UserDao {
         return okta.searchUsers("profile.$PROFILE_RELAY_GUID eq \"$guid\"").firstOrNull()?.toIdmUser()
     }
 
+    // region CRUD methods
+    override fun save(user: User) {
+        UserBuilder.instance()
+            .putProfileProperty(PROFILE_THEKEY_GUID, user.theKeyGuid)
+            .putProfileProperty(PROFILE_RELAY_GUID, user.relayGuid)
+            .setEmail(user.email)
+            .setFirstName(user.firstName)
+            .setLastName(user.lastName)
+            .setPassword(user.password.toCharArray())
+            .buildAndCreate(okta)
+    }
+    // endregion CRUD methods
+
     // region Unsupported CRUD methods
-    override fun save(user: User?) = throw UnsupportedOperationException()
     override fun update(original: User, user: User, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
     override fun update(user: User?, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
     override fun addToGroup(user: User, group: Group) = throw UnsupportedOperationException()

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -60,7 +60,6 @@ class OktaUserDao(private val okta: Client) : UserDao {
     // endregion CRUD methods
 
     // region Unsupported CRUD methods
-    override fun update(original: User, user: User, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
     override fun update(user: User?, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
     override fun addToGroup(user: User, group: Group) = throw UnsupportedOperationException()
     override fun addToGroup(user: User, group: Group, addSecurity: Boolean) = throw UnsupportedOperationException()

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -280,7 +280,6 @@ private fun com.okta.sdk.resource.user.User.matches(expression: Expression?): Bo
 private fun com.okta.sdk.resource.user.User.matches(expression: BooleanExpression) = when (expression.type) {
     BooleanExpression.Type.AND -> expression.components.all { matches(it) }
     BooleanExpression.Type.OR -> expression.components.any { matches(it) }
-    else -> true
 }
 
 private fun com.okta.sdk.resource.user.User.matches(expression: ComparisonExpression): Boolean? {

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -134,10 +134,11 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     // endregion Unsupported Deprecated Methods
 
     // region Unused methods
+    @Deprecated("guids are no longer used and not present within Okta. find users by the key guid instead.")
+    override fun findByGuid(guid: String?, includeDeactivated: Boolean) = null
     override fun findByDesignation(designation: String?, includeDeactivated: Boolean) = TODO("not implemented")
     override fun findByEmployeeId(employeeId: String?, includeDeactivated: Boolean) = TODO("not implemented")
     override fun findByFacebookId(id: String?, includeDeactivated: Boolean) = TODO("not implemented")
-    override fun findByGuid(guid: String?, includeDeactivated: Boolean) = TODO("not implemented")
     override fun getAllGroups(baseSearch: String?) = TODO("not implemented")
     override fun streamUsers(expression: Expression?, deactivated: Boolean, restrict: Boolean) = TODO("not implemented")
     // endregion Unused methods

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -33,8 +33,8 @@ class OktaUserDao(private val okta: Client) : UserDao {
     }
 
     override fun findByTheKeyGuid(guid: String?, includeDeactivated: Boolean) =
-        findOktaUserByTheKeyGuid(guid, includeDeactivated)?.toIdmUser()
-    private fun findOktaUserByTheKeyGuid(guid: String?, includeDeactivated: Boolean) =
+        findOktaUserByTheKeyGuid(guid)?.toIdmUser()
+    private fun findOktaUserByTheKeyGuid(guid: String?) =
         guid?.let { okta.searchUsers("profile.$PROFILE_THEKEY_GUID eq \"$guid\"").firstOrNull() }
 
     override fun findByRelayGuid(guid: String?, includeDeactivated: Boolean): User? {
@@ -59,7 +59,7 @@ class OktaUserDao(private val okta: Client) : UserDao {
 
     override fun update(user: User, vararg attrs: User.Attr) {
         val oktaUser = findOktaUserByOktaUserId(user.oktaUserId)
-            ?: findOktaUserByTheKeyGuid(user.theKeyGuid, true)
+            ?: findOktaUserByTheKeyGuid(user.theKeyGuid)
             ?: throw UserNotFoundException()
 
         var changed = false

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -141,7 +141,8 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             attrsSet.contains(User.Attr.EMAIL) || attrsSet.contains(User.Attr.PASSWORD) ||
             attrsSet.contains(User.Attr.NAME) || attrsSet.contains(User.Attr.CRU_PREFERRED_NAME) ||
             attrsSet.contains(User.Attr.LOCATION) ||
-            attrsSet.contains(User.Attr.EMPLOYEE_NUMBER) || attrsSet.contains(User.Attr.CRU_DESIGNATION)
+            attrsSet.contains(User.Attr.EMPLOYEE_NUMBER) || attrsSet.contains(User.Attr.CRU_DESIGNATION) ||
+            attrsSet.contains(User.Attr.CRU_PROXY_ADDRESSES)
         ) {
             val oktaUser = findOktaUser(user) ?: throw UserNotFoundException()
 
@@ -180,6 +181,10 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
                     }
                     User.Attr.CRU_DESIGNATION -> {
                         oktaUser.profile[PROFILE_US_DESIGNATION] = user.cruDesignation
+                        changed = true
+                    }
+                    User.Attr.CRU_PROXY_ADDRESSES -> {
+                        oktaUser.profile[PROFILE_EMAIL_ALIASES] = user.cruProxyAddresses.toList()
                         changed = true
                     }
                     // we don't care about these attributes anymore

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -50,9 +50,6 @@ class OktaUserDao(private val okta: Client) : UserDao {
 
     // region Unsupported Deprecated Methods
     override fun enqueueAll(queue: BlockingQueue<User>, deactivated: Boolean) = throw UnsupportedOperationException()
-    override fun findAllByEmail(pattern: String?, includeDeactivated: Boolean) = throw UnsupportedOperationException()
-    override fun findAllByFirstName(pattern: String?, deactivated: Boolean) = throw UnsupportedOperationException()
-    override fun findAllByLastName(pattern: String?, deactivated: Boolean) = throw UnsupportedOperationException()
     override fun findAllByGroup(group: Group, includeDeactivated: Boolean) = throw UnsupportedOperationException()
     override fun findAllByQuery(query: SearchQuery) = throw UnsupportedOperationException()
     // endregion Unsupported Deprecated Methods

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -1,0 +1,81 @@
+package org.ccci.idm.user.okta.dao
+
+import com.okta.sdk.client.Client
+import com.okta.sdk.resource.user.EmailStatus
+import org.ccci.idm.user.Group
+import org.ccci.idm.user.SearchQuery
+import org.ccci.idm.user.User
+import org.ccci.idm.user.dao.UserDao
+import org.ccci.idm.user.okta.dao.util.filterUsers
+import org.ccci.idm.user.okta.dao.util.oktaUserId
+import org.ccci.idm.user.okta.dao.util.searchUsers
+import org.ccci.idm.user.query.Expression
+import java.util.concurrent.BlockingQueue
+import com.okta.sdk.resource.user.User as OktaUser
+
+private const val PROFILE_THEKEY_GUID = "theKeyGuid"
+private const val PROFILE_RELAY_GUID = "relayGuid"
+
+class OktaUserDao(private val okta: Client) : UserDao {
+    override fun isReadOnly() = true
+
+    fun findByOktaUserId(id: String?): User? {
+        if (id == null) return null
+        return okta.getUser(id)?.toIdmUser()
+    }
+
+    override fun findByEmail(email: String?, includeDeactivated: Boolean): User? {
+        if (email == null) return null
+        return okta.filterUsers("profile.email eq \"$email\"").firstOrNull()?.toIdmUser()
+    }
+
+    override fun findByTheKeyGuid(guid: String?, includeDeactivated: Boolean): User? {
+        if (guid == null) return null
+        return okta.searchUsers("profile.$PROFILE_THEKEY_GUID eq \"$guid\"").firstOrNull()?.toIdmUser()
+    }
+
+    override fun findByRelayGuid(guid: String?, includeDeactivated: Boolean): User? {
+        if (guid == null) return null
+        return okta.searchUsers("profile.$PROFILE_RELAY_GUID eq \"$guid\"").firstOrNull()?.toIdmUser()
+    }
+
+    // region Unsupported CRUD methods
+    override fun save(user: User?) = throw UnsupportedOperationException()
+    override fun update(original: User, user: User, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
+    override fun update(user: User?, vararg attrs: User.Attr?) = throw UnsupportedOperationException()
+    override fun addToGroup(user: User, group: Group) = throw UnsupportedOperationException()
+    override fun addToGroup(user: User, group: Group, addSecurity: Boolean) = throw UnsupportedOperationException()
+    override fun removeFromGroup(user: User, group: Group) = throw UnsupportedOperationException()
+    // endregion Unsupported CRUD methods
+
+    // region Unsupported Deprecated Methods
+    override fun enqueueAll(queue: BlockingQueue<User>, deactivated: Boolean) = throw UnsupportedOperationException()
+    override fun findAllByEmail(pattern: String?, includeDeactivated: Boolean) = throw UnsupportedOperationException()
+    override fun findAllByFirstName(pattern: String?, deactivated: Boolean) = throw UnsupportedOperationException()
+    override fun findAllByLastName(pattern: String?, deactivated: Boolean) = throw UnsupportedOperationException()
+    override fun findAllByGroup(group: Group, includeDeactivated: Boolean) = throw UnsupportedOperationException()
+    override fun findAllByQuery(query: SearchQuery) = throw UnsupportedOperationException()
+    // endregion Unsupported Deprecated Methods
+
+    // region Unused methods
+    override fun findByDesignation(designation: String?, includeDeactivated: Boolean) = TODO("not implemented")
+    override fun findByEmployeeId(employeeId: String?, includeDeactivated: Boolean) = TODO("not implemented")
+    override fun findByFacebookId(id: String?, includeDeactivated: Boolean) = TODO("not implemented")
+    override fun findByGuid(guid: String?, includeDeactivated: Boolean) = TODO("not implemented")
+    override fun getAllGroups(baseSearch: String?) = TODO("not implemented")
+    override fun streamUsers(expression: Expression?, deactivated: Boolean, restrict: Boolean) = TODO("not implemented")
+    // endregion Unused methods
+
+    private fun OktaUser.toIdmUser(): User {
+        return User().apply {
+            oktaUserId = id
+            email = profile.email
+            isEmailVerified =
+                credentials.emails.firstOrNull { email.equals(it.value, true) }?.status == EmailStatus.VERIFIED
+            firstName = profile.firstName
+            lastName = profile.lastName
+            theKeyGuid = profile.getString(PROFILE_THEKEY_GUID)
+            relayGuid = profile.getString(PROFILE_RELAY_GUID)
+        }
+    }
+}

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -155,7 +155,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             relayGuid = profile.getString(PROFILE_RELAY_GUID)
             employeeId = profile.getString(PROFILE_US_EMPLOYEE_ID)
             cruDesignation = profile.getString(PROFILE_US_DESIGNATION)
-            cruProxyAddresses = profile.getStringList(PROFILE_EMAIL_ALIASES)
+            cruProxyAddresses = profile.getStringList(PROFILE_EMAIL_ALIASES).orEmpty()
         }.also { user -> listeners?.onEach { it.onUserLoaded(user) } }
     }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -31,6 +31,7 @@ private const val PROFILE_FIRST_NAME = "firstName"
 private const val PROFILE_NICK_NAME = "nickName"
 private const val PROFILE_LAST_NAME = "lastName"
 
+private const val PROFILE_PHONE_NUMBER = "primaryPhone"
 private const val PROFILE_CITY = "city"
 private const val PROFILE_STATE = "state"
 private const val PROFILE_ZIP_CODE = "zipCode"
@@ -119,6 +120,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             .setLastName(user.lastName)
             .putProfileProperty(PROFILE_US_EMPLOYEE_ID, user.employeeId)
             .putProfileProperty(PROFILE_US_DESIGNATION, user.cruDesignation)
+            .putProfileProperty(PROFILE_PHONE_NUMBER, user.telephoneNumber)
             .putProfileProperty(PROFILE_CITY, user.city)
             .putProfileProperty(PROFILE_STATE, user.state)
             .putProfileProperty(PROFILE_ZIP_CODE, user.postal)
@@ -140,7 +142,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
         if (
             attrsSet.contains(User.Attr.EMAIL) || attrsSet.contains(User.Attr.PASSWORD) ||
             attrsSet.contains(User.Attr.NAME) || attrsSet.contains(User.Attr.CRU_PREFERRED_NAME) ||
-            attrsSet.contains(User.Attr.LOCATION) ||
+            attrsSet.contains(User.Attr.CONTACT) || attrsSet.contains(User.Attr.LOCATION) ||
             attrsSet.contains(User.Attr.EMPLOYEE_NUMBER) || attrsSet.contains(User.Attr.CRU_DESIGNATION) ||
             attrsSet.contains(User.Attr.CRU_PROXY_ADDRESSES)
         ) {
@@ -166,6 +168,10 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
                     }
                     User.Attr.CRU_PREFERRED_NAME -> {
                         oktaUser.profile[PROFILE_NICK_NAME] = user.rawPreferredName
+                        changed = true
+                    }
+                    User.Attr.CONTACT -> {
+                        oktaUser.profile[PROFILE_PHONE_NUMBER] = user.telephoneNumber
                         changed = true
                     }
                     User.Attr.LOCATION -> {
@@ -254,6 +260,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             firstName = profile.firstName
             preferredName = profile.getString(PROFILE_NICK_NAME)
             lastName = profile.lastName
+            telephoneNumber = profile.getString(PROFILE_PHONE_NUMBER)
             city = profile.getString(PROFILE_CITY)
             state = profile.getString(PROFILE_STATE)
             postal = profile.getString(PROFILE_ZIP_CODE)

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -126,11 +126,21 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     }
     // endregion CRUD methods
 
-    // region Unsupported CRUD methods
-    override fun addToGroup(user: User, group: Group) = throw UnsupportedOperationException()
-    override fun addToGroup(user: User, group: Group, addSecurity: Boolean) = throw UnsupportedOperationException()
-    override fun removeFromGroup(user: User, group: Group) = throw UnsupportedOperationException()
-    // endregion Unsupported CRUD methods
+    // region Group Membership methods
+    override fun addToGroup(user: User, group: Group) {
+        require(group is OktaGroup) { "$group is not an Okta Group" }
+
+        val oktaUser = findOktaUser(user) ?: throw UserNotFoundException()
+        oktaUser.addToGroup(group.id)
+    }
+
+    override fun removeFromGroup(user: User, group: Group) {
+        require(group is OktaGroup) { "$group is not an Okta Group" }
+
+        val oktaUserId = user.oktaUserId ?: findOktaUser(user)?.id ?: throw UserNotFoundException()
+        okta.getGroup(group.id)?.removeUser(oktaUserId)
+    }
+    // endregion Group Membership methods
 
     // region Unsupported Deprecated Methods
     override fun enqueueAll(queue: BlockingQueue<User>, deactivated: Boolean) = throw UnsupportedOperationException()

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -138,6 +138,8 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     // endregion CRUD methods
 
     // region Group methods
+    override fun getGroup(groupId: String?) = groupId?.let { okta.getGroup(groupId) }?.asIdmGroup()
+
     override fun getAllGroups(baseSearch: String?) = okta.listGroups().asSequence()
         .map { it.asIdmGroup() }
         .filter { baseSearch == null || it.isDescendantOfOrEqualTo(baseSearch) }

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -26,6 +26,8 @@ private const val PROFILE_EMAIL_ALIASES = "emailAliases"
 private val DEFAULT_ATTRS = arrayOf(User.Attr.EMAIL, User.Attr.NAME, User.Attr.FLAGS)
 
 class OktaUserDao(private val okta: Client, private val listeners: List<Listener>? = null) : AbstractUserDao() {
+    var initialGroups: Set<String> = emptySet()
+
     fun findByOktaUserId(id: String?) = findOktaUserByOktaUserId(id)?.toIdmUser()
     private fun findOktaUserByOktaUserId(id: String?) = id?.let { okta.getUser(id) }
 
@@ -60,6 +62,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             .putProfileProperty(PROFILE_US_DESIGNATION, user.cruDesignation)
             .putProfileProperty(PROFILE_NICK_NAME, user.rawPreferredName)
             .putProfileProperty(PROFILE_EMAIL_ALIASES, user.cruProxyAddresses.toList())
+            .setGroups(initialGroups)
             .buildAndCreate(okta)
             .also { user.oktaUserId = it.id }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/listeners/FallbackDaoOktaUserDaoListener.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/listeners/FallbackDaoOktaUserDaoListener.kt
@@ -1,7 +1,8 @@
-package org.ccci.idm.user.okta.dao
+package org.ccci.idm.user.okta.dao.listeners
 
 import org.ccci.idm.user.User
 import org.ccci.idm.user.dao.UserDao
+import org.ccci.idm.user.okta.dao.OktaUserDao
 
 private val UPDATABLE_ATTRS = setOf(User.Attr.MFA_SECRET, User.Attr.MFA_INTRUDER_DETECTION, User.Attr.SELFSERVICEKEYS)
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/listeners/OktaPasswordHackForCreateUserListener.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/listeners/OktaPasswordHackForCreateUserListener.kt
@@ -1,0 +1,21 @@
+package org.ccci.idm.user.okta.dao.listeners
+
+import com.okta.authn.sdk.client.AuthenticationClient
+import org.ccci.idm.user.User
+import org.ccci.idm.user.okta.dao.OktaUserDao
+import java.lang.Thread.sleep
+
+class OktaPasswordHackForCreateUserListener(
+    private val authClient: AuthenticationClient,
+    private val sleep: Long = 3000
+) : OktaUserDao.Listener {
+    override fun onUserCreated(user: User) {
+        // HACK: When a new Okta user is created it will trigger provisioning of the account to eDirectory.
+        //       Unfortunately it generates a new random password for the LDAP account and actually provisions the
+        //       password on the next login.
+        //       In addition, if we authenticate the user before the LDAP provisioning completes the password isn't
+        //       pushed to the provisioned account, this is the reason for the sleep.
+        sleep(sleep)
+        authClient.authenticate(user.email, user.password.toCharArray(), null, null)
+    }
+}

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/util/ClientUtils.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/util/ClientUtils.kt
@@ -1,0 +1,7 @@
+package org.ccci.idm.user.okta.dao.util
+
+import com.okta.sdk.client.Client
+import com.okta.sdk.resource.user.UserList
+
+fun Client.filterUsers(filter: String): UserList = listUsers(null, filter, null, null, null)
+fun Client.searchUsers(q: String): UserList = listUsers(null, null, null, q, null)

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/util/UserUtils.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/util/UserUtils.kt
@@ -1,0 +1,11 @@
+package org.ccci.idm.user.okta.dao.util
+
+import org.ccci.idm.user.User
+
+private const val OKTA_USER_ID = "oktaUserId"
+
+internal var User.oktaUserId: String?
+    get() = getImplMeta(OKTA_USER_ID, String::class.java)
+    set(value) {
+        setImplMeta(OKTA_USER_ID, value)
+    }

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <module>api</module>
     <module>inspektr</module>
     <module>ldaptive</module>
+    <module>okta</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <junit.version>4.12</junit.version>
     <kotlin.version>1.3.50</kotlin.version>
     <ldaptive.version>1.2.1</ldaptive.version>
+    <okta.sdk.version>1.5.4</okta.sdk.version>
     <slf4j.version>1.7.7</slf4j.version>
     <spring.version>4.2.0.RELEASE</spring.version>
     <spring-security.version>4.2.6.RELEASE</spring-security.version>
@@ -97,6 +98,26 @@
         <artifactId>ldaptive-beans</artifactId>
         <version>${ldaptive.version}</version>
       </dependency>
+
+      <!-- region Okta modules -->
+      <dependency>
+        <groupId>com.okta.sdk</groupId>
+        <artifactId>okta-sdk-api</artifactId>
+        <version>${okta.sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.okta.sdk</groupId>
+        <artifactId>okta-sdk-impl</artifactId>
+        <version>${okta.sdk.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.okta.sdk</groupId>
+        <artifactId>okta-sdk-httpclient</artifactId>
+        <version>${okta.sdk.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <!-- endregion Okta modules -->
 
       <dependency>
         <groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-
       <!-- ldaptive dependencies -->
       <dependency>
         <groupId>org.ldaptive</groupId>
@@ -161,6 +155,11 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,9 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <version>${kotlin.version}</version>
+        <configuration>
+          <jvmTarget>${maven.compiler.target}</jvmTarget>
+        </configuration>
         <executions>
           <execution>
             <id>compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <junit.version>4.12</junit.version>
     <kotlin.version>1.3.50</kotlin.version>
     <ldaptive.version>1.2.1</ldaptive.version>
+    <okta.authn.version>1.0.0</okta.authn.version>
     <okta.sdk.version>1.5.4</okta.sdk.version>
     <slf4j.version>1.7.7</slf4j.version>
     <spring.version>4.2.0.RELEASE</spring.version>
@@ -100,6 +101,17 @@
       </dependency>
 
       <!-- region Okta modules -->
+      <dependency>
+        <groupId>com.okta.authn.sdk</groupId>
+        <artifactId>okta-authn-sdk-api</artifactId>
+        <version>${okta.authn.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.okta.authn.sdk</groupId>
+        <artifactId>okta-authn-sdk-impl</artifactId>
+        <version>${okta.authn.version}</version>
+        <scope>runtime</scope>
+      </dependency>
       <dependency>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-api</artifactId>


### PR DESCRIPTION
Create an OktaUserDao supporting the following functions:
- Lookup users
- Create/Update users
- Search for users
- List Groups
- Manage Group membership

Things to do in a followup PRs:
- Support Reactivate/Deactivate users
- Potentially optimize API calls to reduce API request load (not sure how this will currently measure up against Okta limits, plus utilizing the built-in SDK caching mechanism should help)