### PR TITLE
OktaUserDao activate deactivate support

### DIFF
--- a/api/src/main/java/org/ccci/idm/user/query/BooleanExpression.java
+++ b/api/src/main/java/org/ccci/idm/user/query/BooleanExpression.java
@@ -1,6 +1,7 @@
 package org.ccci.idm.user.query;
 
 import com.google.common.collect.ImmutableList;
+import org.ccci.idm.user.User;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -42,6 +43,18 @@ public final class BooleanExpression implements Expression {
     @Nonnull
     public List<Expression> getComponents() {
         return components;
+    }
+
+    @Override
+    public boolean matches(@Nonnull final User user) {
+        switch (type) {
+            case AND:
+                return components.stream().allMatch(expr -> expr.matches(user));
+            case OR:
+                return components.stream().anyMatch(expr -> expr.matches(user));
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/api/src/main/java/org/ccci/idm/user/query/ComparisonExpression.java
+++ b/api/src/main/java/org/ccci/idm/user/query/ComparisonExpression.java
@@ -1,6 +1,9 @@
 package org.ccci.idm.user.query;
 
+import com.google.common.base.Strings;
+import kotlin.text.StringsKt;
 import org.ccci.idm.user.Group;
+import org.ccci.idm.user.User;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,5 +54,42 @@ public class ComparisonExpression implements Expression {
     @Nullable
     public Group getGroup() {
         return group;
+    }
+
+    @Override
+    public boolean matches(@Nonnull final User user) {
+        switch (attribute) {
+            case GUID:
+                return matches(user.getTheKeyGuid());
+            case EMAIL:
+                return matches(user.getEmail());
+            case EMAIL_ALIAS:
+                return user.getCruProxyAddresses().stream().anyMatch(this::matches);
+            case FIRST_NAME:
+                return matches(user.getFirstName());
+            case LAST_NAME:
+                return matches(user.getLastName());
+            case US_EMPLOYEE_ID:
+                return matches(user.getEmployeeId());
+            case US_DESIGNATION:
+                return matches(user.getCruDesignation());
+            case GROUP:
+                return user.getGroups().stream().anyMatch(g -> g.equals(group));
+            default:
+                return false;
+        }
+    }
+
+    private boolean matches(@Nullable final String value) {
+        switch (type) {
+            case EQ:
+                return StringsKt.equals(value, this.value, true);
+            case SW:
+                return StringsKt.startsWith(Strings.nullToEmpty(value), Strings.nullToEmpty(this.value), true);
+            case LIKE:
+                throw new UnsupportedOperationException("LIKE comparisons are not currently supported");
+        }
+
+        return false;
     }
 }

--- a/api/src/main/java/org/ccci/idm/user/query/Expression.java
+++ b/api/src/main/java/org/ccci/idm/user/query/Expression.java
@@ -1,5 +1,7 @@
 package org.ccci.idm.user.query;
 
+import org.ccci.idm.user.User;
+
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 
@@ -19,4 +21,6 @@ public interface Expression extends Serializable {
     static Expression not(@Nonnull final Expression expression) {
         return expression.not();
     }
+
+    boolean matches(@Nonnull User user);
 }

--- a/api/src/main/java/org/ccci/idm/user/query/NotExpression.java
+++ b/api/src/main/java/org/ccci/idm/user/query/NotExpression.java
@@ -1,5 +1,7 @@
 package org.ccci.idm.user.query;
 
+import org.ccci.idm.user.User;
+
 import javax.annotation.Nonnull;
 
 public class NotExpression implements Expression {
@@ -15,6 +17,11 @@ public class NotExpression implements Expression {
     @Nonnull
     public Expression getComponent() {
         return component;
+    }
+
+    @Override
+    public boolean matches(@Nonnull final User user) {
+        return !component.matches(user);
     }
 
     @Override

--- a/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoExpressionConversionTest.java
+++ b/ldaptive/src/test/java/org/ccci/idm/user/ldaptive/dao/LdaptiveUserDaoExpressionConversionTest.java
@@ -12,13 +12,21 @@ import static org.junit.Assert.fail;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.ccci.idm.user.User;
 import org.ccci.idm.user.query.Expression;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
+
 @RunWith(JUnitParamsRunner.class)
 public class LdaptiveUserDaoExpressionConversionTest {
-    private static class UnsupportedExpression implements Expression {}
+    private static class UnsupportedExpression implements Expression {
+        @Override
+        public boolean matches(@Nonnull final User user) {
+            return false;
+        }
+    }
 
     private LdaptiveUserDao dao = new LdaptiveUserDao();
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -72,7 +72,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     }
 
     override fun findByTheKeyGuid(guid: String?, includeDeactivated: Boolean) =
-        findOktaUserByTheKeyGuid(guid)?.asIdmUser()
+        findOktaUserByTheKeyGuid(guid)?.asIdmUser()?.takeIf { !it.isDeactivated || includeDeactivated }
     private fun findOktaUserByTheKeyGuid(guid: String?) =
         guid?.let { okta.searchUsers("profile.$PROFILE_THEKEY_GUID eq \"$guid\"").firstOrNull() }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -305,7 +305,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
         return User().apply {
             oktaUserId = id
             theKeyGuid = profile.getString(PROFILE_THEKEY_GUID)
-            relayGuid = profile.getString(PROFILE_RELAY_GUID)
+            relayGuid = profile.getString(PROFILE_RELAY_GUID) ?: theKeyGuid
 
             isDeactivated = profile.email.startsWith(DEACTIVATED_PREFIX) && profile.email.endsWith(DEACTIVATED_SUFFIX)
             email = if (isDeactivated) profile.getString(PROFILE_ORIGINAL_EMAIL) else profile.email

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -342,7 +342,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
 
     private fun com.okta.sdk.resource.group.Group.asIdmGroup() = OktaGroup(id, profile.name)
 
-    public interface Listener {
+    interface Listener {
         fun onUserLoaded(user: User) = Unit
         fun onUserCreated(user: User) = Unit
         fun onUserUpdated(user: User, vararg attrs: User.Attr) = Unit

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -76,10 +76,9 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     private fun findOktaUserByTheKeyGuid(guid: String?) =
         guid?.let { okta.searchUsers("profile.$PROFILE_THEKEY_GUID eq \"$guid\"").firstOrNull() }
 
-    override fun findByRelayGuid(guid: String?, includeDeactivated: Boolean): User? {
-        if (guid == null) return null
-        return okta.searchUsers("profile.$PROFILE_RELAY_GUID eq \"$guid\"").firstOrNull()?.asIdmUser()
-    }
+    override fun findByRelayGuid(guid: String?, includeDeactivated: Boolean) =
+        guid?.let { okta.searchUsers("profile.$PROFILE_RELAY_GUID eq \"$guid\"").firstOrNull()?.asIdmUser() }
+            ?.takeIf { !it.isDeactivated || includeDeactivated }
 
     // region Stream Users
     override fun streamUsers(

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -89,8 +89,9 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     ): Stream<User> {
         val search = expression?.toOktaExpression(includeDeactivated)
         return okta.listUsers(null, null, null, search, null).stream()
-            .restrictMaxAllowed(restrictMaxAllowed)
             .map { it.asIdmUser(loadGroups = false) }
+            .filter { !it.isDeactivated || includeDeactivated }
+            .restrictMaxAllowed(restrictMaxAllowed)
     }
 
     override fun streamUsersInGroup(

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -3,6 +3,7 @@ package org.ccci.idm.user.okta.dao
 import com.okta.sdk.client.Client
 import com.okta.sdk.resource.user.EmailStatus
 import com.okta.sdk.resource.user.UserBuilder
+import com.okta.sdk.resource.user.UserStatus
 import org.ccci.idm.user.Group
 import org.ccci.idm.user.SearchQuery
 import org.ccci.idm.user.User
@@ -253,12 +254,12 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     override fun reactivate(user: User) {
         val oktaUser = findOktaUser(user) ?: return
         super.reactivate(user)
-        oktaUser.unsuspend()
+        if (oktaUser.status == UserStatus.SUSPENDED) oktaUser.unsuspend()
     }
 
     override fun deactivate(user: User) {
         val oktaUser = findOktaUser(user) ?: return
-        oktaUser.suspend()
+        if (oktaUser.status != UserStatus.SUSPENDED) oktaUser.suspend()
         super.deactivate(user)
     }
     // endregion CRUD methods


### PR DESCRIPTION
when an account is deactivated for The Key in Okta we perform the following actions:
1. suspend the account
2. set the `original_email` to the user's email address
3. update the user's email address to be a unique placeholder. This will free up the email address to be used by another account.

The intention of deactivation in The Key is to remove an account in a reversible manner and not let the deactivated account interfere with a user wanting to reuse the email address.