### PR TITLE
Okta deactivate fixes

### DIFF
--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -268,7 +268,11 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             else -> oktaUser.suspend()
         }
 
+        // update user to indicate it is deactivated
         super.deactivate(user)
+
+        // deprovision accounts that we couldn't suspend and that were never actually activated
+        if (oktaUser.status == UserStatus.PROVISIONED) oktaUser.deactivate()
     }
     // endregion CRUD methods
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -258,7 +258,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     }
 
     override fun deactivate(user: User) {
-        // suspend the account before update attributes
+        // suspend the account before updating attributes
         val oktaUser = findOktaUser(user) ?: return
         when (oktaUser.status) {
             // account is already suspended
@@ -268,10 +268,10 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             else -> oktaUser.suspend()
         }
 
-        // update user to indicate it is deactivated
+        // update account to indicate it is deactivated
         super.deactivate(user)
 
-        // deprovision accounts that we couldn't suspend and that were never actually activated
+        // de-provision accounts that we couldn't suspend and that were never actually activated
         if (oktaUser.status == UserStatus.PROVISIONED) oktaUser.deactivate()
     }
     // endregion CRUD methods

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -258,8 +258,16 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
     }
 
     override fun deactivate(user: User) {
+        // suspend the account before update attributes
         val oktaUser = findOktaUser(user) ?: return
-        if (oktaUser.status != UserStatus.SUSPENDED) oktaUser.suspend()
+        when (oktaUser.status) {
+            // account is already suspended
+            UserStatus.SUSPENDED -> Unit
+            // account was created but hasn't been verified yet, Okta doesn't support suspending these accounts
+            UserStatus.PROVISIONED -> Unit
+            else -> oktaUser.suspend()
+        }
+
         super.deactivate(user)
     }
     // endregion CRUD methods


### PR DESCRIPTION
When a user creates a new Okta account they are in a `PROVISIONED` state until the user activates the account by clicking a link in their email. Accounts in this state can not be suspended.

Because the account can't be suspended, just renaming the account to our deactivated account pattern still allows the user to interact with the account if they can determine the deactivated email address or more easily if they just click the `Activate Account` link that was originally emailed to them.

To make sure the account is unusable we trigger Okta deactivation (which is a destructive action and prevents any future updates to the account), but I feel this is acceptable because the account was never actively used anywhere, so there shouldn't be any need to restore it.

If we encounter an account that does need to be restored, it can be manually restored via the Okta user interface, or the user can just create a brand new account since the deactivated account was never used anywhere

References:
[User States](https://help.okta.com/en/prod/Content/Topics/Directory/end-user-states.htm) (`Pending user action` is equivalent to `PROVISIONED`)