### PR TITLE
Process Okta exceptions when creating a new user

### DIFF
--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -324,7 +324,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
 
     private fun ResourceException.asIdmException(checkPasswordException: Boolean = false) = when {
         checkPasswordException && code == "E0000001" && error.message == "Api validation failed: password" ->
-            InvalidPasswordUserException(causes.firstOrNull()?.summary)
+            InvalidPasswordUserException(causes.firstOrNull()?.summary?.removePrefix("password: "))
         else -> OktaDaoException(this)
     }
 

--- a/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
+++ b/okta/src/main/java/org/ccci/idm/user/okta/dao/OktaUserDao.kt
@@ -129,7 +129,7 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
         assertWritable()
         assertValidUser(user)
 
-        UserBuilder.instance()
+        val builder = UserBuilder.instance()
             .putProfileProperty(PROFILE_THEKEY_GUID, user.theKeyGuid)
             .putProfileProperty(PROFILE_RELAY_GUID, user.relayGuid)
             .setEmail(user.email)
@@ -140,6 +140,8 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             .putProfileProperty(PROFILE_US_EMPLOYEE_ID, user.employeeId)
             .putProfileProperty(PROFILE_US_DESIGNATION, user.cruDesignation)
             .putProfileProperty(PROFILE_PHONE_NUMBER, user.telephoneNumber)
+            .putProfileProperty(PROFILE_EMAIL_ALIASES, user.cruProxyAddresses.toList())
+            .setGroups(initialGroups)
 
             // Location profile attributes
             .putProfileProperty(PROFILE_CITY, user.city)
@@ -153,10 +155,12 @@ class OktaUserDao(private val okta: Client, private val listeners: List<Listener
             .putProfileProperty(PROFILE_DEPARTMENT, user.departmentNumber)
             .putProfileProperty(PROFILE_MANAGER_ID, user.cruManagerID)
 
-            .putProfileProperty(PROFILE_EMAIL_ALIASES, user.cruProxyAddresses.toList())
-            .setGroups(initialGroups)
-            .buildAndCreate(okta)
-            .also { user.oktaUserId = it.id }
+        try {
+            builder.buildAndCreate(okta)
+                .also { user.oktaUserId = it.id }
+        } catch (e: ResourceException) {
+            throw e.asIdmException(checkPasswordException = true)
+        }
 
         listeners?.onEach { it.onUserCreated(user) }
     }

--- a/okta/src/test/java/org/ccci/idm/user/okta/dao/BaseOktaUserDaoTest.kt
+++ b/okta/src/test/java/org/ccci/idm/user/okta/dao/BaseOktaUserDaoTest.kt
@@ -1,0 +1,35 @@
+package org.ccci.idm.user.okta.dao
+
+import com.nhaarman.mockitokotlin2.mock
+import com.okta.sdk.client.Client
+import com.okta.sdk.resource.user.User
+import org.junit.Before
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+
+abstract class BaseOktaUserDaoTest {
+    protected lateinit var okta: Client
+    protected lateinit var dao: OktaUserDao
+
+    protected lateinit var oktaUser: User
+
+    @Before
+    fun setupDao() {
+        okta = mock()
+        dao = OktaUserDao(okta)
+    }
+
+    @Before
+    fun setupOktaMocks() {
+        oktaUser = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    }
+
+    protected companion object {
+        const val INVALID_PASSWORD_MESSAGE = "INVALID_PASSWORD_MESSAGE"
+
+        val invalidPasswordError = mapOf(
+            "errorCode" to "E0000001",
+            "errorSummary" to "Api validation failed: password",
+            "errorCauses" to listOf(mapOf("errorSummary" to "password: $INVALID_PASSWORD_MESSAGE"))
+        )
+    }
+}

--- a/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoSaveIT.kt
+++ b/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoSaveIT.kt
@@ -1,0 +1,54 @@
+package org.ccci.idm.user.okta.dao
+
+import com.okta.sdk.authc.credentials.TokenClientCredentials
+import com.okta.sdk.client.Client
+import com.okta.sdk.client.Clients
+import org.ccci.idm.user.User
+import org.ccci.idm.user.exception.InvalidPasswordUserException
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import java.util.Random
+import java.util.UUID
+
+@RunWith(SpringJUnit4ClassRunner::class)
+@ContextConfiguration("/config.xml")
+class OktaUserDaoSaveIT {
+    @Value("\${okta.orgUrl:#{null}}")
+    private var orgUrl: String? = null
+
+    @Value("\${okta.apiKey:#{null}}")
+    private var apiKey: String? = null
+
+    private lateinit var client: Client
+    private lateinit var dao: OktaUserDao
+
+    @Before
+    fun setup() {
+        assumeTrue("okta.orgUrl not configured", orgUrl != null)
+        assumeTrue("okta.apiKey not configured", apiKey != null)
+
+        client = Clients.builder()
+            .setOrgUrl(orgUrl)
+            .setClientCredentials(TokenClientCredentials(apiKey))
+            .build()
+        dao = OktaUserDao(client)
+    }
+
+    @Test(expected = InvalidPasswordUserException::class)
+    fun testInvalidPasswordUserException() {
+        val user = User().apply {
+            theKeyGuid = UUID.randomUUID().toString()
+            relayGuid = theKeyGuid
+            email = "test-${Random().nextInt()}@example.com"
+            firstName = "Test"
+            lastName = "User"
+        }
+        user.password = "a"
+        dao.save(user)
+    }
+}

--- a/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoSaveTest.kt
+++ b/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoSaveTest.kt
@@ -1,0 +1,53 @@
+package org.ccci.idm.user.okta.dao
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.stub
+import com.nhaarman.mockitokotlin2.whenever
+import com.okta.sdk.impl.error.DefaultError
+import com.okta.sdk.resource.ResourceException
+import com.okta.sdk.resource.user.PasswordCredential
+import com.okta.sdk.resource.user.UserCredentials
+import org.ccci.idm.user.User
+import org.ccci.idm.user.exception.InvalidPasswordUserException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+import com.okta.sdk.resource.user.User as OktaUser
+
+class OktaUserDaoSaveTest : BaseOktaUserDaoTest() {
+    @Before
+    fun setupMocksForSave() {
+        okta.stub {
+            on { instantiate(OktaUser::class.java) } doReturn oktaUser
+            on { instantiate(UserCredentials::class.java) } doReturn mock()
+            on { instantiate(PasswordCredential::class.java) } doReturn mock()
+        }
+        whenever(oktaUser.profile).thenReturn(mock())
+    }
+
+    @Test
+    fun testInvalidPasswordUserException() {
+        val user = User().apply {
+            email = "test@example.com"
+            theKeyGuid = UUID.randomUUID().toString()
+            relayGuid = theKeyGuid
+            firstName = "Test"
+            lastName = "User"
+            password = "a"
+        }
+        whenever(okta.createUser(any(), anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenThrow(ResourceException(DefaultError(invalidPasswordError)))
+
+        try {
+            dao.save(user)
+            fail("creating a user with an invalid password didn't throw an exception")
+        } catch (e: InvalidPasswordUserException) {
+            assertEquals(INVALID_PASSWORD_MESSAGE, e.message)
+        }
+    }
+}

--- a/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoUpdateUserTest.kt
+++ b/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoUpdateUserTest.kt
@@ -48,7 +48,7 @@ class OktaUserDaoUpdateUserTest {
         val error = mapOf(
             "errorCode" to "E0000001",
             "errorSummary" to "Api validation failed: password",
-            "errorCauses" to listOf(mapOf("errorSummary" to INVALID_PASSWORD_MESSAGE))
+            "errorCauses" to listOf(mapOf("errorSummary" to "password: $INVALID_PASSWORD_MESSAGE"))
         )
         whenever(oktaUser.update()) doThrow ResourceException(DefaultError(error))
 

--- a/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoUpdateUserTest.kt
+++ b/okta/src/test/java/org/ccci/idm/user/okta/dao/OktaUserDaoUpdateUserTest.kt
@@ -1,11 +1,7 @@
 package org.ccci.idm.user.okta.dao
 
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.doThrow
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.okta.sdk.client.Client
 import com.okta.sdk.impl.error.DefaultError
 import com.okta.sdk.resource.ResourceException
 import org.ccci.idm.user.User
@@ -15,18 +11,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import java.util.UUID
-import com.okta.sdk.resource.user.User as OktaUser
 
 private const val OKTA_USER_ID = "oktaUserId"
-private const val INVALID_PASSWORD_MESSAGE = "INVALID_PASSWORD_MESSAGE"
 
-class OktaUserDaoUpdateUserTest {
-    private lateinit var client: Client
-    private lateinit var dao: OktaUserDao
-
-    private lateinit var oktaUser: OktaUser
+class OktaUserDaoUpdateUserTest : BaseOktaUserDaoTest() {
     private val user = User().apply {
         oktaUserId = OKTA_USER_ID
         email = "test@example.com"
@@ -36,21 +25,12 @@ class OktaUserDaoUpdateUserTest {
 
     @Before
     fun setup() {
-        oktaUser = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-        client = mock {
-            whenever(it.getUser(OKTA_USER_ID)) doReturn oktaUser
-        }
-        dao = OktaUserDao(client)
+        whenever(okta.getUser(OKTA_USER_ID)).thenReturn(oktaUser)
     }
 
     @Test
     fun testInvalidPasswordUserException() {
-        val error = mapOf(
-            "errorCode" to "E0000001",
-            "errorSummary" to "Api validation failed: password",
-            "errorCauses" to listOf(mapOf("errorSummary" to "password: $INVALID_PASSWORD_MESSAGE"))
-        )
-        whenever(oktaUser.update()) doThrow ResourceException(DefaultError(error))
+        whenever(oktaUser.update()).thenThrow(ResourceException(DefaultError(invalidPasswordError)))
 
         user.password = "a"
         try {


### PR DESCRIPTION
This will expose more usable exceptions when there is an error creating a new user.